### PR TITLE
feat: CostService実装＋Frontend CI vitest追加

### DIFF
--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -33,3 +33,19 @@ jobs:
           name: frontend-dist
           path: frontend/dist
           retention-days: 7
+
+  test:
+    name: Test (Vitest)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+      - run: npm ci --legacy-peer-deps
+      - run: npx vitest run --reporter=verbose

--- a/backend/app/api/v1/routers/costs.py
+++ b/backend/app/api/v1/routers/costs.py
@@ -2,7 +2,6 @@
 
 import math
 import uuid
-from decimal import Decimal
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException, Query
@@ -11,7 +10,6 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.rbac import UserRole, require_roles
 from app.db.base import get_db
 from app.models.user import User
-from app.repositories.cost import CostRecordRepository, WorkHourRepository
 from app.schemas.common import ApiResponse, PaginatedResponse, PaginationMeta
 from app.schemas.cost import (
     CostRecordCreate,
@@ -20,6 +18,7 @@ from app.schemas.cost import (
     WorkHourCreate,
     WorkHourResponse,
 )
+from app.services.cost_service import CostNotFoundError, CostService
 
 router = APIRouter(tags=["原価・工数管理"])
 
@@ -42,10 +41,9 @@ async def create_cost_record(
         ),
     ],
 ):
-    repo = CostRecordRepository(db)
-    payload.project_id = project_id
-    record = await repo.create(payload, created_by=current_user.id)
-    return ApiResponse(data=CostRecordResponse.model_validate(record))
+    svc = CostService(db)
+    data = await svc.create_record(project_id, payload, created_by=current_user.id)
+    return ApiResponse(data=data)
 
 
 @router.get(
@@ -66,12 +64,10 @@ async def list_cost_records(
     page: int = Query(default=1, ge=1),
     per_page: int = Query(default=20, ge=1, le=100),
 ):
-    repo = CostRecordRepository(db)
-    offset = (page - 1) * per_page
-    items = await repo.list(project_id, offset=offset, limit=per_page)
-    total = await repo.count(project_id)
+    svc = CostService(db)
+    items, total = await svc.list_records(project_id, page, per_page)
     return PaginatedResponse(
-        data=[CostRecordResponse.model_validate(i) for i in items],
+        data=items,
         meta=PaginationMeta(
             total=total,
             page=page,
@@ -98,31 +94,9 @@ async def get_cost_summary(
     ],
 ):
     """予実対比サマリー"""
-    repo = CostRecordRepository(db)
-    summary = await repo.get_summary(project_id)
-    by_category = await repo.get_summary_by_category(project_id)
-
-    total_budgeted = summary["total_budget"]
-    total_actual = summary["total_actual"]
-    variance = summary["variance"]
-    variance_rate = float(variance / total_budgeted * 100) if total_budgeted else 0.0
-
-    return ApiResponse(
-        data=CostSummary(
-            project_id=project_id,
-            total_budgeted=Decimal(str(total_budgeted)),
-            total_actual=Decimal(str(total_actual)),
-            variance=Decimal(str(variance)),
-            variance_rate=round(variance_rate, 2),
-            by_category={
-                item["category"]: {
-                    "budgeted": float(item["budget"]),
-                    "actual": float(item["actual"]),
-                }
-                for item in by_category
-            },
-        )
-    )
+    svc = CostService(db)
+    summary = await svc.get_summary(project_id)
+    return ApiResponse(data=summary)
 
 
 @router.post(
@@ -143,10 +117,9 @@ async def create_work_hour(
         ),
     ],
 ):
-    repo = WorkHourRepository(db)
-    payload.project_id = project_id
-    wh = await repo.create(payload, created_by=current_user.id)
-    return ApiResponse(data=WorkHourResponse.model_validate(wh))
+    svc = CostService(db)
+    data = await svc.create_work_hour(project_id, payload, created_by=current_user.id)
+    return ApiResponse(data=data)
 
 
 @router.delete(
@@ -166,8 +139,8 @@ async def delete_cost_record(
         ),
     ],
 ):
-    repo = CostRecordRepository(db)
-    record = await repo.get_by_id(record_id)
-    if not record or record.project_id != project_id:
-        raise HTTPException(status_code=404, detail="原価記録が見つかりません")
-    await repo.soft_delete(record)
+    svc = CostService(db)
+    try:
+        await svc.delete_record(project_id, record_id)
+    except CostNotFoundError as err:
+        raise HTTPException(status_code=404, detail="原価記録が見つかりません") from err

--- a/backend/app/services/cost_service.py
+++ b/backend/app/services/cost_service.py
@@ -1,0 +1,84 @@
+"""
+原価管理サービス（ビジネスロジック層）
+予実計算・コストサマリー生成
+"""
+
+import uuid
+from decimal import Decimal
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.repositories.cost import CostRecordRepository, WorkHourRepository
+from app.schemas.cost import (
+    CostRecordCreate,
+    CostRecordResponse,
+    CostSummary,
+    WorkHourCreate,
+    WorkHourResponse,
+)
+
+
+class CostService:
+    def __init__(self, db: AsyncSession):
+        self.db = db
+        self.cost_repo = CostRecordRepository(db)
+        self.hour_repo = WorkHourRepository(db)
+
+    async def create_record(
+        self, project_id: uuid.UUID, data: CostRecordCreate, created_by: uuid.UUID
+    ) -> CostRecordResponse:
+        data.project_id = project_id
+        record = await self.cost_repo.create(data, created_by=created_by)
+        return CostRecordResponse.model_validate(record)
+
+    async def list_records(
+        self, project_id: uuid.UUID, page: int, per_page: int
+    ) -> tuple[list[CostRecordResponse], int]:
+        offset = (page - 1) * per_page
+        items = await self.cost_repo.list(project_id, offset=offset, limit=per_page)
+        total = await self.cost_repo.count(project_id)
+        return [CostRecordResponse.model_validate(i) for i in items], total
+
+    async def get_summary(self, project_id: uuid.UUID) -> CostSummary:
+        """予実対比サマリーを生成"""
+        summary = await self.cost_repo.get_summary(project_id)
+        by_category = await self.cost_repo.get_summary_by_category(project_id)
+
+        total_budgeted = summary["total_budget"]
+        total_actual = summary["total_actual"]
+        variance = summary["variance"]
+        variance_rate = (
+            float(variance / total_budgeted * 100) if total_budgeted else 0.0
+        )
+
+        return CostSummary(
+            project_id=project_id,
+            total_budgeted=Decimal(str(total_budgeted)),
+            total_actual=Decimal(str(total_actual)),
+            variance=Decimal(str(variance)),
+            variance_rate=round(variance_rate, 2),
+            by_category={
+                item["category"]: {
+                    "budgeted": float(item["budget"]),
+                    "actual": float(item["actual"]),
+                }
+                for item in by_category
+            },
+        )
+
+    async def create_work_hour(
+        self, project_id: uuid.UUID, data: WorkHourCreate, created_by: uuid.UUID
+    ) -> WorkHourResponse:
+        data.project_id = project_id
+        wh = await self.hour_repo.create(data, created_by=created_by)
+        return WorkHourResponse.model_validate(wh)
+
+    async def delete_record(self, project_id: uuid.UUID, record_id: uuid.UUID) -> None:
+        record = await self.cost_repo.get_by_id(record_id)
+        if not record or record.project_id != project_id:
+            raise CostNotFoundError("原価記録が見つかりません")
+        await self.cost_repo.soft_delete(record)
+
+
+class CostNotFoundError(Exception):
+    """原価記録が見つからない"""

--- a/backend/tests/unit/test_cost_service.py
+++ b/backend/tests/unit/test_cost_service.py
@@ -1,0 +1,164 @@
+"""CostService のユニットテスト"""
+
+import uuid
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_cost_summary_empty_project(auth_client, admin_headers):
+    """存在しないプロジェクトの予実サマリーはゼロを返す"""
+    project_id = uuid.uuid4()
+    response = await auth_client.get(
+        f"/api/v1/projects/{project_id}/cost-summary",
+        headers=admin_headers,
+    )
+    assert response.status_code == 200
+    data = response.json()["data"]
+    assert float(data["total_budgeted"]) == 0
+    assert float(data["total_actual"]) == 0
+    assert float(data["variance"]) == 0
+    assert data["variance_rate"] == 0.0
+
+
+@pytest.mark.asyncio
+async def test_cost_record_crud(auth_client, admin_headers):
+    """原価記録のCRUD（作成→一覧→削除）"""
+    # First create a project
+    project_resp = await auth_client.post(
+        "/api/v1/projects",
+        json={
+            "project_code": f"COST-TEST-{uuid.uuid4().hex[:6]}",
+            "name": "Cost Test Project",
+            "client_name": "Test Client",
+            "status": "PLANNING",
+        },
+        headers=admin_headers,
+    )
+    assert project_resp.status_code == 201
+    project_id = project_resp.json()["data"]["id"]
+
+    # Create cost record
+    create_resp = await auth_client.post(
+        f"/api/v1/projects/{project_id}/cost-records",
+        json={
+            "project_id": project_id,
+            "category": "材料費",
+            "description": "鉄骨資材",
+            "budgeted_amount": "1000000",
+            "actual_amount": "950000",
+            "record_date": "2026-04-01",
+        },
+        headers=admin_headers,
+    )
+    assert create_resp.status_code == 201
+    record = create_resp.json()["data"]
+    assert record["category"] == "材料費"
+    record_id = record["id"]
+
+    # List
+    list_resp = await auth_client.get(
+        f"/api/v1/projects/{project_id}/cost-records",
+        headers=admin_headers,
+    )
+    assert list_resp.status_code == 200
+    assert list_resp.json()["meta"]["total"] >= 1
+
+    # Delete
+    del_resp = await auth_client.delete(
+        f"/api/v1/projects/{project_id}/cost-records/{record_id}",
+        headers=admin_headers,
+    )
+    assert del_resp.status_code == 204
+
+
+@pytest.mark.asyncio
+async def test_cost_summary_with_records(auth_client, admin_headers):
+    """予実サマリーが正しく計算される"""
+    # Create project
+    project_resp = await auth_client.post(
+        "/api/v1/projects",
+        json={
+            "project_code": f"SUM-TEST-{uuid.uuid4().hex[:6]}",
+            "name": "Summary Test",
+            "client_name": "Client",
+            "status": "ACTIVE",
+        },
+        headers=admin_headers,
+    )
+    project_id = project_resp.json()["data"]["id"]
+
+    # Create two cost records
+    for budget, actual, cat in [
+        ("500000", "480000", "材料費"),
+        ("300000", "320000", "外注費"),
+    ]:
+        await auth_client.post(
+            f"/api/v1/projects/{project_id}/cost-records",
+            json={
+                "project_id": project_id,
+                "category": cat,
+                "description": f"test {cat}",
+                "budgeted_amount": budget,
+                "actual_amount": actual,
+                "record_date": "2026-04-01",
+            },
+            headers=admin_headers,
+        )
+
+    # Get summary
+    resp = await auth_client.get(
+        f"/api/v1/projects/{project_id}/cost-summary",
+        headers=admin_headers,
+    )
+    assert resp.status_code == 200
+    data = resp.json()["data"]
+    assert float(data["total_budgeted"]) == 800000
+    assert float(data["total_actual"]) == 800000
+    assert "by_category" in data
+    assert len(data["by_category"]) == 2
+
+
+@pytest.mark.asyncio
+async def test_cost_record_delete_not_found(auth_client, admin_headers):
+    """存在しない原価記録の削除は404"""
+    project_id = uuid.uuid4()
+    fake_id = uuid.uuid4()
+    resp = await auth_client.delete(
+        f"/api/v1/projects/{project_id}/cost-records/{fake_id}",
+        headers=admin_headers,
+    )
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_work_hour_create(auth_client, admin_headers):
+    """工数記録の作成"""
+    # Create project
+    project_resp = await auth_client.post(
+        "/api/v1/projects",
+        json={
+            "project_code": f"WH-TEST-{uuid.uuid4().hex[:6]}",
+            "name": "WorkHour Test",
+            "client_name": "Client",
+            "status": "ACTIVE",
+        },
+        headers=admin_headers,
+    )
+    project_id = project_resp.json()["data"]["id"]
+
+    resp = await auth_client.post(
+        f"/api/v1/projects/{project_id}/work-hours",
+        json={
+            "project_id": project_id,
+            "work_date": "2026-04-01",
+            "hours": "8.0",
+            "work_type": "REGULAR",
+            "description": "基礎工事",
+        },
+        headers=admin_headers,
+    )
+    assert resp.status_code == 201
+    data = resp.json()["data"]
+    assert data["work_type"] == "REGULAR"
+    assert float(data["hours"]) == 8.0


### PR DESCRIPTION
## Summary
- CostService 新規作成 — 予実計算ビジネスロジックを Router から Service 層に分離
- costs.py Router を CostService 経由に移行（Router → Service → Repository 3層構造）
- ci-frontend.yml に vitest テスト実行ジョブ追加（品質ゲート強化）
- CostService テスト 5件追加（Backend テスト 134 → 139件）

## Architecture
```
costs.py Router → CostService → CostRecordRepository / WorkHourRepository
```

## Test plan
- [x] Backend: `pytest` — 139 passed (coverage 85%)
- [x] Backend: `ruff format --check` — 82 files formatted
- [x] Backend: `ruff check` — All checks passed
- [x] Frontend: `vitest run` — 23 passed
- [ ] Backend CI (GitHub Actions)
- [ ] Frontend CI with new vitest job

## Impact
- Service 層が 2 → 3 クラスに拡充（AuthService / StorageService / CostService）
- Frontend CI がテスト実行を含むようになり品質ゲート強化

🤖 Generated with [Claude Code](https://claude.com/claude-code)