### PR TITLE
feat: Service層100%完了（Safety/DailyReport/User）

### DIFF
--- a/backend/app/api/v1/routers/daily_reports.py
+++ b/backend/app/api/v1/routers/daily_reports.py
@@ -17,13 +17,13 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.rbac import UserRole, require_roles
 from app.db.base import get_db
 from app.models.user import User
-from app.repositories.daily_report import DailyReportRepository
 from app.schemas.common import ApiResponse, PaginatedResponse, PaginationMeta
 from app.schemas.daily_report import (
     DailyReportCreate,
     DailyReportResponse,
     DailyReportUpdate,
 )
+from app.services.daily_report_service import DailyReportService, ReportNotFoundError
 
 router = APIRouter(tags=["日報管理"])
 
@@ -49,12 +49,10 @@ async def list_daily_reports(
     page: int = Query(default=1, ge=1),
     per_page: int = Query(default=20, ge=1, le=100),
 ):
-    repo = DailyReportRepository(db)
-    offset = (page - 1) * per_page
-    reports = await repo.list(project_id=project_id, offset=offset, limit=per_page)
-    total = await repo.count(project_id=project_id)
+    svc = DailyReportService(db)
+    reports, total = await svc.list_reports(project_id, page, per_page)
     return PaginatedResponse(
-        data=[DailyReportResponse.model_validate(r) for r in reports],
+        data=reports,
         meta=PaginationMeta(
             total=total,
             page=page,
@@ -82,10 +80,9 @@ async def create_daily_report(
         ),
     ],
 ):
-    payload.project_id = project_id
-    repo = DailyReportRepository(db)
-    report = await repo.create(payload, created_by=current_user.id)
-    return ApiResponse(data=DailyReportResponse.model_validate(report))
+    svc = DailyReportService(db)
+    report = await svc.create_report(project_id, payload, created_by=current_user.id)
+    return ApiResponse(data=report)
 
 
 @router.get(
@@ -106,11 +103,12 @@ async def get_daily_report(
         ),
     ],
 ):
-    repo = DailyReportRepository(db)
-    report = await repo.get_by_id(report_id)
-    if not report:
-        raise HTTPException(status_code=404, detail="日報が見つかりません")
-    return ApiResponse(data=DailyReportResponse.model_validate(report))
+    svc = DailyReportService(db)
+    try:
+        report = await svc.get_report(report_id)
+    except ReportNotFoundError:
+        raise HTTPException(status_code=404, detail="日報が見つかりません") from None
+    return ApiResponse(data=report)
 
 
 @router.put(
@@ -129,12 +127,12 @@ async def update_daily_report(
         ),
     ],
 ):
-    repo = DailyReportRepository(db)
-    report = await repo.get_by_id(report_id)
-    if not report:
-        raise HTTPException(status_code=404, detail="日報が見つかりません")
-    report = await repo.update(report, payload, updated_by=current_user.id)
-    return ApiResponse(data=DailyReportResponse.model_validate(report))
+    svc = DailyReportService(db)
+    try:
+        report = await svc.update_report(report_id, payload, updated_by=current_user.id)
+    except ReportNotFoundError:
+        raise HTTPException(status_code=404, detail="日報が見つかりません") from None
+    return ApiResponse(data=report)
 
 
 @router.delete("/daily-reports/{report_id}", status_code=status.HTTP_204_NO_CONTENT)
@@ -145,9 +143,9 @@ async def delete_daily_report(
         User, Depends(require_roles(UserRole.ADMIN, UserRole.PROJECT_MANAGER))
     ],
 ):
-    repo = DailyReportRepository(db)
-    report = await repo.get_by_id(report_id)
-    if not report:
-        raise HTTPException(status_code=404, detail="日報が見つかりません")
-    await repo.soft_delete(report, deleted_by=current_user.id)
+    svc = DailyReportService(db)
+    try:
+        await svc.delete_report(report_id, deleted_by=current_user.id)
+    except ReportNotFoundError:
+        raise HTTPException(status_code=404, detail="日報が見つかりません") from None
     return None

--- a/backend/app/api/v1/routers/safety.py
+++ b/backend/app/api/v1/routers/safety.py
@@ -10,13 +10,17 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.rbac import UserRole, require_roles
 from app.db.base import get_db
 from app.models.user import User
-from app.repositories.safety import QualityInspectionRepository, SafetyCheckRepository
 from app.schemas.common import ApiResponse, PaginatedResponse, PaginationMeta
 from app.schemas.safety import (
     QualityInspectionCreate,
     QualityInspectionResponse,
     SafetyCheckCreate,
     SafetyCheckResponse,
+)
+from app.services.safety_service import (
+    QualityInspectionNotFoundError,
+    SafetyCheckNotFoundError,
+    SafetyService,
 )
 
 router = APIRouter(tags=["安全・品質管理"])
@@ -40,10 +44,11 @@ async def create_safety_check(
         ),
     ],
 ):
-    repo = SafetyCheckRepository(db)
-    payload.project_id = project_id
-    check = await repo.create(payload, created_by=current_user.id)
-    return ApiResponse(data=SafetyCheckResponse.model_validate(check))
+    svc = SafetyService(db)
+    data = await svc.create_safety_check(
+        project_id, payload, created_by=current_user.id
+    )
+    return ApiResponse(data=data)
 
 
 @router.get(
@@ -67,12 +72,10 @@ async def list_safety_checks(
     page: int = Query(default=1, ge=1),
     per_page: int = Query(default=20, ge=1, le=100),
 ):
-    repo = SafetyCheckRepository(db)
-    offset = (page - 1) * per_page
-    items = await repo.list(project_id, offset=offset, limit=per_page)
-    total = await repo.count(project_id)
+    svc = SafetyService(db)
+    items, total = await svc.list_safety_checks(project_id, page, per_page)
     return PaginatedResponse(
-        data=[SafetyCheckResponse.model_validate(i) for i in items],
+        data=items,
         meta=PaginationMeta(
             total=total,
             page=page,
@@ -100,10 +103,11 @@ async def create_quality_inspection(
         ),
     ],
 ):
-    repo = QualityInspectionRepository(db)
-    payload.project_id = project_id
-    insp = await repo.create(payload, created_by=current_user.id)
-    return ApiResponse(data=QualityInspectionResponse.model_validate(insp))
+    svc = SafetyService(db)
+    data = await svc.create_quality_inspection(
+        project_id, payload, created_by=current_user.id
+    )
+    return ApiResponse(data=data)
 
 
 @router.get(
@@ -127,12 +131,10 @@ async def list_quality_inspections(
     page: int = Query(default=1, ge=1),
     per_page: int = Query(default=20, ge=1, le=100),
 ):
-    repo = QualityInspectionRepository(db)
-    offset = (page - 1) * per_page
-    items = await repo.list(project_id, offset=offset, limit=per_page)
-    total = await repo.count(project_id)
+    svc = SafetyService(db)
+    items, total = await svc.list_quality_inspections(project_id, page, per_page)
     return PaginatedResponse(
-        data=[QualityInspectionResponse.model_validate(i) for i in items],
+        data=items,
         meta=PaginationMeta(
             total=total,
             page=page,
@@ -159,11 +161,13 @@ async def delete_safety_check(
         ),
     ],
 ):
-    repo = SafetyCheckRepository(db)
-    check = await repo.get_by_id(check_id)
-    if not check or check.project_id != project_id:
-        raise HTTPException(status_code=404, detail="安全チェックが見つかりません")
-    await repo.soft_delete(check)
+    svc = SafetyService(db)
+    try:
+        await svc.delete_safety_check(project_id, check_id)
+    except SafetyCheckNotFoundError:
+        raise HTTPException(
+            status_code=404, detail="安全チェックが見つかりません"
+        ) from None
 
 
 @router.delete(
@@ -183,8 +187,10 @@ async def delete_quality_inspection(
         ),
     ],
 ):
-    repo = QualityInspectionRepository(db)
-    insp = await repo.get_by_id(inspection_id)
-    if not insp or insp.project_id != project_id:
-        raise HTTPException(status_code=404, detail="品質検査が見つかりません")
-    await repo.soft_delete(insp)
+    svc = SafetyService(db)
+    try:
+        await svc.delete_quality_inspection(project_id, inspection_id)
+    except QualityInspectionNotFoundError:
+        raise HTTPException(
+            status_code=404, detail="品質検査が見つかりません"
+        ) from None

--- a/backend/app/api/v1/routers/users.py
+++ b/backend/app/api/v1/routers/users.py
@@ -17,9 +17,14 @@ from app.core.rbac import UserRole, require_roles
 from app.core.security import get_password_hash
 from app.db.base import get_db
 from app.models.user import User
-from app.repositories.user import UserRepository
 from app.schemas.common import ApiResponse, PaginatedResponse, PaginationMeta
 from app.schemas.user import UserCreate, UserListResponse, UserUpdate
+from app.services.user_service import (
+    DuplicateEmailError,
+    SelfDeletionError,
+    UserNotFoundError,
+    UserService,
+)
 
 router = APIRouter(prefix="/users", tags=["ユーザー管理"])
 
@@ -31,13 +36,11 @@ async def list_users(
     page: int = Query(default=1, ge=1),
     per_page: int = Query(default=20, ge=1, le=100),
 ):
-    repo = UserRepository(db)
-    offset = (page - 1) * per_page
-    users = await repo.list(offset=offset, limit=per_page)
-    total = await repo.count()
+    svc = UserService(db)
+    users, total = await svc.list_users(page, per_page)
 
     return PaginatedResponse(
-        data=[UserListResponse.model_validate(u) for u in users],
+        data=users,
         meta=PaginationMeta(
             total=total,
             page=page,
@@ -57,18 +60,14 @@ async def create_user(
     db: Annotated[AsyncSession, Depends(get_db)],
     current_user: Annotated[User, Depends(require_roles(UserRole.ADMIN))],
 ):
-    repo = UserRepository(db)
-    existing = await repo.get_by_email(payload.email)
-    if existing:
-        raise HTTPException(
-            status_code=400,
-            detail="このメールアドレスは既に登録されています",
+    svc = UserService(db)
+    try:
+        user = await svc.create_user(
+            payload, hashed_password=get_password_hash(payload.password)
         )
-
-    user = await repo.create(
-        payload, hashed_password=get_password_hash(payload.password)
-    )
-    return ApiResponse(data=UserListResponse.model_validate(user))
+    except DuplicateEmailError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from None
+    return ApiResponse(data=user)
 
 
 @router.get("/{user_id}", response_model=ApiResponse[UserListResponse])
@@ -77,11 +76,12 @@ async def get_user(
     db: Annotated[AsyncSession, Depends(get_db)],
     current_user: Annotated[User, Depends(require_roles(UserRole.ADMIN))],
 ):
-    repo = UserRepository(db)
-    user = await repo.get_by_id(user_id)
-    if not user:
-        raise HTTPException(status_code=404, detail="ユーザーが見つかりません")
-    return ApiResponse(data=UserListResponse.model_validate(user))
+    svc = UserService(db)
+    try:
+        user = await svc.get_user(user_id)
+    except UserNotFoundError as e:
+        raise HTTPException(status_code=404, detail=str(e)) from None
+    return ApiResponse(data=user)
 
 
 @router.put("/{user_id}", response_model=ApiResponse[UserListResponse])
@@ -91,13 +91,12 @@ async def update_user(
     db: Annotated[AsyncSession, Depends(get_db)],
     current_user: Annotated[User, Depends(require_roles(UserRole.ADMIN))],
 ):
-    repo = UserRepository(db)
-    user = await repo.get_by_id(user_id)
-    if not user:
-        raise HTTPException(status_code=404, detail="ユーザーが見つかりません")
-
-    user = await repo.update(user, payload)
-    return ApiResponse(data=UserListResponse.model_validate(user))
+    svc = UserService(db)
+    try:
+        user = await svc.update_user(user_id, payload)
+    except UserNotFoundError as e:
+        raise HTTPException(status_code=404, detail=str(e)) from None
+    return ApiResponse(data=user)
 
 
 @router.delete("/{user_id}", status_code=204)
@@ -106,10 +105,10 @@ async def delete_user(
     db: Annotated[AsyncSession, Depends(get_db)],
     current_user: Annotated[User, Depends(require_roles(UserRole.ADMIN))],
 ):
-    repo = UserRepository(db)
-    user = await repo.get_by_id(user_id)
-    if not user:
-        raise HTTPException(status_code=404, detail="ユーザーが見つかりません")
-    if user.id == current_user.id:
-        raise HTTPException(status_code=400, detail="自分自身は削除できません")
-    await repo.soft_delete(user)
+    svc = UserService(db)
+    try:
+        await svc.delete_user(user_id, current_user.id)
+    except UserNotFoundError as e:
+        raise HTTPException(status_code=404, detail=str(e)) from None
+    except SelfDeletionError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from None

--- a/backend/app/services/daily_report_service.py
+++ b/backend/app/services/daily_report_service.py
@@ -1,0 +1,60 @@
+"""
+日報サービス（ビジネスロジック層）
+"""
+
+import uuid
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.repositories.daily_report import DailyReportRepository
+from app.schemas.daily_report import (
+    DailyReportCreate,
+    DailyReportResponse,
+    DailyReportUpdate,
+)
+
+
+class ReportNotFoundError(Exception):
+    """日報が見つからない"""
+
+
+class DailyReportService:
+    def __init__(self, db: AsyncSession):
+        self.db = db
+        self.repo = DailyReportRepository(db)
+
+    async def create_report(
+        self, project_id: uuid.UUID, data: DailyReportCreate, created_by: uuid.UUID
+    ) -> DailyReportResponse:
+        data.project_id = project_id
+        report = await self.repo.create(data, created_by=created_by)
+        return DailyReportResponse.model_validate(report)
+
+    async def list_reports(
+        self, project_id: uuid.UUID, page: int, per_page: int
+    ) -> tuple[list[DailyReportResponse], int]:
+        offset = (page - 1) * per_page
+        items = await self.repo.list(project_id, offset=offset, limit=per_page)
+        total = await self.repo.count(project_id)
+        return [DailyReportResponse.model_validate(i) for i in items], total
+
+    async def get_report(self, report_id: uuid.UUID) -> DailyReportResponse:
+        report = await self.repo.get_by_id(report_id)
+        if not report:
+            raise ReportNotFoundError("日報が見つかりません")
+        return DailyReportResponse.model_validate(report)
+
+    async def update_report(
+        self, report_id: uuid.UUID, data: DailyReportUpdate, updated_by: uuid.UUID
+    ) -> DailyReportResponse:
+        report = await self.repo.get_by_id(report_id)
+        if not report:
+            raise ReportNotFoundError("日報が見つかりません")
+        report = await self.repo.update(report, data, updated_by=updated_by)
+        return DailyReportResponse.model_validate(report)
+
+    async def delete_report(self, report_id: uuid.UUID, deleted_by: uuid.UUID) -> None:
+        report = await self.repo.get_by_id(report_id)
+        if not report:
+            raise ReportNotFoundError("日報が見つかりません")
+        await self.repo.soft_delete(report, deleted_by=deleted_by)

--- a/backend/app/services/safety_service.py
+++ b/backend/app/services/safety_service.py
@@ -1,0 +1,84 @@
+"""
+安全・品質管理サービス（ビジネスロジック層）
+"""
+
+import uuid
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.repositories.safety import QualityInspectionRepository, SafetyCheckRepository
+from app.schemas.safety import (
+    QualityInspectionCreate,
+    QualityInspectionResponse,
+    SafetyCheckCreate,
+    SafetyCheckResponse,
+)
+
+
+class SafetyService:
+    def __init__(self, db: AsyncSession):
+        self.db = db
+        self.check_repo = SafetyCheckRepository(db)
+        self.inspection_repo = QualityInspectionRepository(db)
+
+    async def create_safety_check(
+        self,
+        project_id: uuid.UUID,
+        data: SafetyCheckCreate,
+        created_by: uuid.UUID,
+    ) -> SafetyCheckResponse:
+        data.project_id = project_id
+        check = await self.check_repo.create(data, created_by=created_by)
+        return SafetyCheckResponse.model_validate(check)
+
+    async def list_safety_checks(
+        self, project_id: uuid.UUID, page: int, per_page: int
+    ) -> tuple[list[SafetyCheckResponse], int]:
+        offset = (page - 1) * per_page
+        items = await self.check_repo.list(project_id, offset=offset, limit=per_page)
+        total = await self.check_repo.count(project_id)
+        return [SafetyCheckResponse.model_validate(i) for i in items], total
+
+    async def delete_safety_check(
+        self, project_id: uuid.UUID, check_id: uuid.UUID
+    ) -> None:
+        check = await self.check_repo.get_by_id(check_id)
+        if not check or check.project_id != project_id:
+            raise SafetyCheckNotFoundError("安全チェックが見つかりません")
+        await self.check_repo.soft_delete(check)
+
+    async def create_quality_inspection(
+        self,
+        project_id: uuid.UUID,
+        data: QualityInspectionCreate,
+        created_by: uuid.UUID,
+    ) -> QualityInspectionResponse:
+        data.project_id = project_id
+        insp = await self.inspection_repo.create(data, created_by=created_by)
+        return QualityInspectionResponse.model_validate(insp)
+
+    async def list_quality_inspections(
+        self, project_id: uuid.UUID, page: int, per_page: int
+    ) -> tuple[list[QualityInspectionResponse], int]:
+        offset = (page - 1) * per_page
+        items = await self.inspection_repo.list(
+            project_id, offset=offset, limit=per_page
+        )
+        total = await self.inspection_repo.count(project_id)
+        return [QualityInspectionResponse.model_validate(i) for i in items], total
+
+    async def delete_quality_inspection(
+        self, project_id: uuid.UUID, inspection_id: uuid.UUID
+    ) -> None:
+        insp = await self.inspection_repo.get_by_id(inspection_id)
+        if not insp or insp.project_id != project_id:
+            raise QualityInspectionNotFoundError("品質検査が見つかりません")
+        await self.inspection_repo.soft_delete(insp)
+
+
+class SafetyCheckNotFoundError(Exception):
+    """安全チェックが見つからない"""
+
+
+class QualityInspectionNotFoundError(Exception):
+    """品質検査が見つからない"""

--- a/backend/app/services/user_service.py
+++ b/backend/app/services/user_service.py
@@ -1,0 +1,68 @@
+"""
+User management service (business logic layer)
+"""
+
+import uuid
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.repositories.user import UserRepository
+from app.schemas.user import UserCreate, UserListResponse, UserUpdate
+
+
+class UserService:
+    def __init__(self, db: AsyncSession):
+        self.db = db
+        self.repo = UserRepository(db)
+
+    async def create_user(
+        self, data: UserCreate, hashed_password: str
+    ) -> UserListResponse:
+        existing = await self.repo.get_by_email(data.email)
+        if existing:
+            raise DuplicateEmailError("このメールアドレスは既に登録されています")
+        user = await self.repo.create(data, hashed_password=hashed_password)
+        return UserListResponse.model_validate(user)
+
+    async def list_users(
+        self, page: int, per_page: int
+    ) -> tuple[list[UserListResponse], int]:
+        offset = (page - 1) * per_page
+        users = await self.repo.list(offset=offset, limit=per_page)
+        total = await self.repo.count()
+        return [UserListResponse.model_validate(u) for u in users], total
+
+    async def get_user(self, user_id: uuid.UUID) -> UserListResponse:
+        user = await self.repo.get_by_id(user_id)
+        if not user:
+            raise UserNotFoundError("ユーザーが見つかりません")
+        return UserListResponse.model_validate(user)
+
+    async def update_user(
+        self, user_id: uuid.UUID, data: UserUpdate
+    ) -> UserListResponse:
+        user = await self.repo.get_by_id(user_id)
+        if not user:
+            raise UserNotFoundError("ユーザーが見つかりません")
+        user = await self.repo.update(user, data)
+        return UserListResponse.model_validate(user)
+
+    async def delete_user(self, user_id: uuid.UUID, current_user_id: uuid.UUID) -> None:
+        user = await self.repo.get_by_id(user_id)
+        if not user:
+            raise UserNotFoundError("ユーザーが見つかりません")
+        if user.id == current_user_id:
+            raise SelfDeletionError("自分自身は削除できません")
+        await self.repo.soft_delete(user)
+
+
+class UserNotFoundError(Exception):
+    """User not found"""
+
+
+class DuplicateEmailError(Exception):
+    """Email already registered"""
+
+
+class SelfDeletionError(Exception):
+    """Cannot delete self"""

--- a/backend/tests/unit/test_daily_report_service.py
+++ b/backend/tests/unit/test_daily_report_service.py
@@ -1,0 +1,68 @@
+"""DailyReportService のユニットテスト"""
+
+import uuid
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_daily_report_crud(auth_client, admin_headers):
+    """日報のCRUD全操作"""
+    project_resp = await auth_client.post(
+        "/api/v1/projects",
+        json={
+            "project_code": f"DR-{uuid.uuid4().hex[:6]}",
+            "name": "Report Test",
+            "client_name": "Client",
+            "status": "ACTIVE",
+        },
+        headers=admin_headers,
+    )
+    project_id = project_resp.json()["data"]["id"]
+
+    # Create
+    resp = await auth_client.post(
+        f"/api/v1/projects/{project_id}/daily-reports",
+        json={
+            "project_id": project_id,
+            "report_date": "2026-04-04",
+            "weather": "晴れ",
+            "temperature_high": 22.5,
+            "temperature_low": 12.0,
+            "work_description": "基礎工事実施",
+            "workers_count": 15,
+        },
+        headers=admin_headers,
+    )
+    assert resp.status_code == 201
+    report = resp.json()["data"]
+    report_id = report["id"]
+
+    # Get
+    resp = await auth_client.get(
+        f"/api/v1/daily-reports/{report_id}", headers=admin_headers
+    )
+    assert resp.status_code == 200
+    assert resp.json()["data"]["weather"] == "晴れ"
+
+    # List
+    resp = await auth_client.get(
+        f"/api/v1/projects/{project_id}/daily-reports", headers=admin_headers
+    )
+    assert resp.status_code == 200
+    assert resp.json()["meta"]["total"] >= 1
+
+    # Delete
+    resp = await auth_client.delete(
+        f"/api/v1/daily-reports/{report_id}", headers=admin_headers
+    )
+    assert resp.status_code == 204
+
+
+@pytest.mark.asyncio
+async def test_daily_report_not_found(auth_client, admin_headers):
+    """存在しない日報は404"""
+    resp = await auth_client.get(
+        f"/api/v1/daily-reports/{uuid.uuid4()}", headers=admin_headers
+    )
+    assert resp.status_code == 404

--- a/backend/tests/unit/test_safety_service.py
+++ b/backend/tests/unit/test_safety_service.py
@@ -1,0 +1,117 @@
+"""SafetyService のユニットテスト"""
+
+import uuid
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_safety_check_create_and_list(auth_client, admin_headers):
+    """安全チェックの作成と一覧"""
+    project_resp = await auth_client.post(
+        "/api/v1/projects",
+        json={
+            "project_code": f"SAF-{uuid.uuid4().hex[:6]}",
+            "name": "Safety Test",
+            "client_name": "Client",
+            "status": "ACTIVE",
+        },
+        headers=admin_headers,
+    )
+    project_id = project_resp.json()["data"]["id"]
+
+    resp = await auth_client.post(
+        f"/api/v1/projects/{project_id}/safety-checks",
+        json={
+            "project_id": project_id,
+            "check_date": "2026-04-04",
+            "check_type": "日次",
+            "items_total": 10,
+            "items_ok": 9,
+            "items_ng": 1,
+            "overall_result": "PASS",
+        },
+        headers=admin_headers,
+    )
+    assert resp.status_code == 201
+
+    list_resp = await auth_client.get(
+        f"/api/v1/projects/{project_id}/safety-checks",
+        headers=admin_headers,
+    )
+    assert list_resp.status_code == 200
+    assert list_resp.json()["meta"]["total"] >= 1
+
+
+@pytest.mark.asyncio
+async def test_safety_check_delete(auth_client, admin_headers):
+    """安全チェックの削除"""
+    project_resp = await auth_client.post(
+        "/api/v1/projects",
+        json={
+            "project_code": f"SAFD-{uuid.uuid4().hex[:6]}",
+            "name": "Del Test",
+            "client_name": "Client",
+            "status": "ACTIVE",
+        },
+        headers=admin_headers,
+    )
+    project_id = project_resp.json()["data"]["id"]
+
+    create_resp = await auth_client.post(
+        f"/api/v1/projects/{project_id}/safety-checks",
+        json={
+            "project_id": project_id,
+            "check_date": "2026-04-04",
+            "check_type": "日次",
+        },
+        headers=admin_headers,
+    )
+    check_id = create_resp.json()["data"]["id"]
+
+    del_resp = await auth_client.delete(
+        f"/api/v1/projects/{project_id}/safety-checks/{check_id}",
+        headers=admin_headers,
+    )
+    assert del_resp.status_code == 204
+
+
+@pytest.mark.asyncio
+async def test_safety_check_delete_not_found(auth_client, admin_headers):
+    """存在しない安全チェックの削除は404"""
+    project_id = uuid.uuid4()
+    resp = await auth_client.delete(
+        f"/api/v1/projects/{project_id}/safety-checks/{uuid.uuid4()}",
+        headers=admin_headers,
+    )
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_quality_inspection_create(auth_client, admin_headers):
+    """品質検査の作成"""
+    project_resp = await auth_client.post(
+        "/api/v1/projects",
+        json={
+            "project_code": f"QI-{uuid.uuid4().hex[:6]}",
+            "name": "QI Test",
+            "client_name": "Client",
+            "status": "ACTIVE",
+        },
+        headers=admin_headers,
+    )
+    project_id = project_resp.json()["data"]["id"]
+
+    resp = await auth_client.post(
+        f"/api/v1/projects/{project_id}/quality-inspections",
+        json={
+            "project_id": project_id,
+            "inspection_date": "2026-04-04",
+            "inspection_type": "出来形",
+            "target_item": "基礎コンクリート",
+            "result": "PASS",
+        },
+        headers=admin_headers,
+    )
+    assert resp.status_code == 201
+    assert resp.json()["data"]["result"] == "PASS"

--- a/backend/tests/unit/test_user_service.py
+++ b/backend/tests/unit/test_user_service.py
@@ -1,0 +1,80 @@
+"""UserService のユニットテスト"""
+
+import uuid
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_user_crud(auth_client, admin_headers):
+    """ユーザーのCRUD"""
+    email = f"test-{uuid.uuid4().hex[:6]}@example.com"
+
+    # Create
+    resp = await auth_client.post(
+        "/api/v1/users",
+        json={
+            "email": email,
+            "full_name": "テストユーザー",
+            "password": "SecurePass123!",
+            "role": "VIEWER",
+        },
+        headers=admin_headers,
+    )
+    assert resp.status_code == 201
+    user = resp.json()["data"]
+    user_id = user["id"]
+    assert user["email"] == email
+
+    # Get
+    resp = await auth_client.get(f"/api/v1/users/{user_id}", headers=admin_headers)
+    assert resp.status_code == 200
+
+    # Update
+    resp = await auth_client.put(
+        f"/api/v1/users/{user_id}",
+        json={"full_name": "更新ユーザー", "role": "PROJECT_MANAGER"},
+        headers=admin_headers,
+    )
+    assert resp.status_code == 200
+    assert resp.json()["data"]["full_name"] == "更新ユーザー"
+
+    # List
+    resp = await auth_client.get("/api/v1/users", headers=admin_headers)
+    assert resp.status_code == 200
+    assert resp.json()["meta"]["total"] >= 1
+
+
+@pytest.mark.asyncio
+async def test_user_duplicate_email(auth_client, admin_headers):
+    """重複メールアドレスは400"""
+    email = f"dup-{uuid.uuid4().hex[:6]}@example.com"
+    payload = {
+        "email": email,
+        "full_name": "First",
+        "password": "SecurePass123!",
+        "role": "VIEWER",
+    }
+    resp1 = await auth_client.post("/api/v1/users", json=payload, headers=admin_headers)
+    assert resp1.status_code == 201
+
+    resp2 = await auth_client.post("/api/v1/users", json=payload, headers=admin_headers)
+    assert resp2.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_user_not_found(auth_client, admin_headers):
+    """存在しないユーザーは404"""
+    resp = await auth_client.get(f"/api/v1/users/{uuid.uuid4()}", headers=admin_headers)
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_user_self_delete_blocked(auth_client, admin_headers):
+    """自分自身の削除は400"""
+    from tests.conftest import ADMIN_USER_ID
+
+    resp = await auth_client.delete(
+        f"/api/v1/users/{ADMIN_USER_ID}", headers=admin_headers
+    )
+    assert resp.status_code == 400


### PR DESCRIPTION
## Summary
- **SafetyService**: 安全チェック/品質検査 CRUD + 404ハンドリング
- **DailyReportService**: 日報 CRUD + 404ハンドリング
- **UserService**: ユーザー CRUD + 重複メール検出 + 自己削除防止
- **全 Router が Router → Service → Repository の3層構造に統一完了**
- Backend テスト 148 → 158件（+10）

## Service Layer (Complete)
| Service | 責務 |
|---------|------|
| AuthService | 認証・トークン管理 |
| StorageService | MinIO ファイル操作 |
| CostService | 予実計算・コストサマリー |
| KnowledgeService | AI検索・スコアリング |
| ITSMService | ステータス遷移・承認 |
| ProjectService | 案件管理・重複チェック |
| **SafetyService** | **安全チェック・品質検査** |
| **DailyReportService** | **日報管理** |
| **UserService** | **ユーザー管理・自己削除防止** |

## Test plan
- [x] Backend: `pytest` — 158 passed (coverage 84%)
- [x] `ruff format --check` / `ruff check` — All clean
- [ ] Backend CI (GitHub Actions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)