### PR TITLE
feat(ui): Phase 2 — 共通UIコンポーネントへの統一（4ページ）

### DIFF
--- a/frontend/src/pages/cost/CostPage.tsx
+++ b/frontend/src/pages/cost/CostPage.tsx
@@ -1,8 +1,9 @@
-import { useState } from "react";
+import React, { useState } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { DollarSign, Plus, TrendingUp, TrendingDown, X } from "lucide-react";
 import { costApi, CostRecordCreate, CostRecord } from "@/api/cost";
 import { projectsApi } from "@/api/projects";
+import { Badge, Button, Card, Skeleton } from "@/components/ui";
 
 const CATEGORY_OPTIONS = [
   { value: "LABOR", label: "労務費" },
@@ -111,13 +112,16 @@ export default function CostPage() {
           <DollarSign className="w-7 h-7 text-primary-600" />
           原価管理
         </h2>
-        <button className="btn-primary" onClick={openModal} disabled={!selectedProjectId}>
-          <Plus className="w-4 h-4 mr-1" />
+        <Button
+          leftIcon={<Plus className="w-4 h-4" />}
+          onClick={openModal}
+          disabled={!selectedProjectId}
+        >
           新規原価記録
-        </button>
+        </Button>
       </div>
 
-      <div className="card">
+      <Card>
         <label className="block text-sm font-medium text-gray-700 mb-1">プロジェクト選択</label>
         <select
           className="input w-64"
@@ -131,7 +135,7 @@ export default function CostPage() {
             </option>
           ))}
         </select>
-      </div>
+      </Card>
 
       {error && (
         <div className="bg-red-50 border border-red-300 text-red-700 px-4 py-3 rounded">
@@ -140,51 +144,53 @@ export default function CostPage() {
       )}
 
       {!selectedProjectId ? (
-        <div className="card text-center py-16 text-gray-400">
+        <Card className="text-center py-16 text-gray-400">
           <DollarSign className="w-12 h-12 mx-auto mb-3" />
           <p className="text-lg font-medium">プロジェクトを選択してください</p>
-        </div>
+        </Card>
       ) : isLoading ? (
-        <div className="card text-center py-16 text-gray-400">読み込み中...</div>
+        <Card className="space-y-3">
+          {[...Array(4)].map((_, i) => <Skeleton key={i} className="h-10 w-full" />)}
+        </Card>
       ) : (
         <>
           {summary && (
             <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
-              <div className="card">
+              <Card>
                 <p className="text-xs font-medium text-gray-500 mb-1">予算合計</p>
                 <p className="text-xl font-bold text-gray-900">
                   {formatCurrency(summary.total_budgeted)}
                 </p>
-              </div>
-              <div className="card">
+              </Card>
+              <Card>
                 <p className="text-xs font-medium text-gray-500 mb-1">実績合計</p>
                 <p className="text-xl font-bold text-gray-900">
                   {formatCurrency(summary.total_actual)}
                 </p>
-              </div>
-              <div className="card">
+              </Card>
+              <Card>
                 <p className="text-xs font-medium text-gray-500 mb-1">差異</p>
                 <p className={`text-xl font-bold flex items-center gap-1 ${isOver ? "text-red-600" : "text-green-600"}`}>
                   {isOver ? <TrendingUp className="w-5 h-5" /> : <TrendingDown className="w-5 h-5" />}
                   {formatCurrency(Math.abs(summary.variance))}
                 </p>
-              </div>
-              <div className="card">
+              </Card>
+              <Card>
                 <p className="text-xs font-medium text-gray-500 mb-1">達成率</p>
                 <p className={`text-xl font-bold ${achieveRate > 100 ? "text-red-600" : "text-green-600"}`}>
                   {achieveRate}%
                 </p>
-              </div>
+              </Card>
             </div>
           )}
 
           {records.length === 0 ? (
-            <div className="card text-center py-16 text-gray-400">
+            <Card className="text-center py-16 text-gray-400">
               <DollarSign className="w-12 h-12 mx-auto mb-3" />
               <p className="text-lg font-medium">原価記録がありません</p>
-            </div>
+            </Card>
           ) : (
-            <div className="card p-0 overflow-hidden">
+            <Card padding="none" className="overflow-hidden">
               <table className="w-full text-sm">
                 <thead className="bg-gray-50 border-b border-gray-200">
                   <tr>
@@ -200,7 +206,7 @@ export default function CostPage() {
                       <tr key={r.id} className="hover:bg-gray-50">
                         <td className="px-4 py-3">{r.record_date}</td>
                         <td className="px-4 py-3">
-                          <span className="badge-info">{CATEGORY_LABEL[r.category] ?? r.category}</span>
+                          <Badge variant="info" size="sm">{CATEGORY_LABEL[r.category] ?? r.category}</Badge>
                         </td>
                         <td className="px-4 py-3 max-w-xs truncate">{r.description}</td>
                         <td className="px-4 py-3 text-right">{formatCurrency(r.budgeted_amount ?? 0)}</td>
@@ -210,18 +216,20 @@ export default function CostPage() {
                         </td>
                         <td className="px-4 py-3">
                           <div className="flex items-center gap-2">
-                            <button
-                              className="text-xs px-2 py-1 rounded bg-blue-100 text-blue-700 hover:bg-blue-200 transition-colors"
+                            <Button
+                              variant="ghost"
+                              size="sm"
                               onClick={() => window.alert("編集機能は今後対応予定です")}
                             >
                               編集
-                            </button>
-                            <button
-                              className="text-xs px-2 py-1 rounded bg-red-100 text-red-700 hover:bg-red-200 transition-colors"
+                            </Button>
+                            <Button
+                              variant="danger"
+                              size="sm"
                               onClick={() => handleDelete(r.id)}
                             >
                               削除
-                            </button>
+                            </Button>
                           </div>
                         </td>
                       </tr>
@@ -229,7 +237,7 @@ export default function CostPage() {
                   })}
                 </tbody>
               </table>
-            </div>
+            </Card>
           )}
         </>
       )}
@@ -284,12 +292,12 @@ export default function CostPage() {
                 <p className="text-red-600 text-sm">作成に失敗しました。</p>
               )}
               <div className="flex justify-end gap-3 pt-2">
-                <button type="button" className="btn-secondary" onClick={() => setShowModal(false)}>
+                <Button type="button" variant="secondary" onClick={() => setShowModal(false)}>
                   キャンセル
-                </button>
-                <button type="submit" className="btn-primary" disabled={createMutation.isPending}>
-                  {createMutation.isPending ? "作成中..." : "作成"}
-                </button>
+                </Button>
+                <Button type="submit" loading={createMutation.isPending}>
+                  作成
+                </Button>
               </div>
             </form>
           </div>

--- a/frontend/src/pages/projects/ProjectsPage.tsx
+++ b/frontend/src/pages/projects/ProjectsPage.tsx
@@ -1,8 +1,9 @@
-import { useState } from "react";
+import React, { useState } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { Link } from "react-router-dom";
 import { Plus, Search, Building2 } from "lucide-react";
 import { projectsApi, ProjectCreate } from "@/api/projects";
+import { Badge, Button, Card, Skeleton } from "@/components/ui";
 
 const STATUS_OPTIONS = [
   { value: "PLANNING", label: "計画中" },
@@ -12,12 +13,14 @@ const STATUS_OPTIONS = [
   { value: "CANCELLED", label: "中止" },
 ];
 
-const STATUS_BADGE: Record<string, string> = {
-  PLANNING: "badge-info",
-  IN_PROGRESS: "badge-success",
-  ON_HOLD: "badge-warning",
-  COMPLETED: "badge-info",
-  CANCELLED: "badge-danger",
+type BadgeVariant = "info" | "success" | "warning" | "danger";
+
+const STATUS_VARIANT: Record<string, BadgeVariant> = {
+  PLANNING: "info",
+  IN_PROGRESS: "success",
+  ON_HOLD: "warning",
+  COMPLETED: "info",
+  CANCELLED: "danger",
 };
 
 const STATUS_LABEL: Record<string, string> = {
@@ -58,10 +61,9 @@ export default function ProjectsPage() {
     <div className="space-y-6">
       <div className="flex items-center justify-between">
         <h2 className="text-2xl font-bold text-gray-900">工事案件一覧</h2>
-        <button className="btn-primary" onClick={() => setShowModal(true)}>
-          <Plus className="w-4 h-4 mr-1" />
+        <Button leftIcon={<Plus className="w-4 h-4" />} onClick={() => setShowModal(true)}>
           新規案件
-        </button>
+        </Button>
       </div>
 
       {/* Search */}
@@ -78,9 +80,11 @@ export default function ProjectsPage() {
 
       {/* Table */}
       {isLoading ? (
-        <div className="card text-center py-12 text-gray-400">読み込み中...</div>
+        <Card className="space-y-3">
+          {[...Array(5)].map((_, i) => <Skeleton key={i} className="h-10 w-full" />)}
+        </Card>
       ) : (
-        <div className="card p-0 overflow-hidden">
+        <Card padding="none" className="overflow-hidden">
           <table className="min-w-full divide-y divide-gray-200">
             <thead className="bg-gray-50">
               <tr>
@@ -108,9 +112,9 @@ export default function ProjectsPage() {
                     {p.start_date ?? "—"} 〜 {p.end_date ?? "—"}
                   </td>
                   <td className="px-4 py-3">
-                    <span className={STATUS_BADGE[p.status] ?? "badge-info"}>
+                    <Badge variant={STATUS_VARIANT[p.status] ?? "info"} size="sm">
                       {STATUS_LABEL[p.status] ?? p.status}
-                    </span>
+                    </Badge>
                   </td>
                 </tr>
               ))}
@@ -132,24 +136,26 @@ export default function ProjectsPage() {
                 全 {data.meta.total} 件 / {data.meta.total_pages ?? data.meta.pages} ページ
               </span>
               <div className="flex gap-2">
-                <button
+                <Button
+                  variant="secondary"
+                  size="sm"
                   onClick={() => setPage((p) => Math.max(1, p - 1))}
                   disabled={page === 1}
-                  className="btn-secondary py-1 px-3 disabled:opacity-40"
                 >
                   前へ
-                </button>
-                <button
+                </Button>
+                <Button
+                  variant="secondary"
+                  size="sm"
                   onClick={() => setPage((p) => p + 1)}
                   disabled={page >= (data.meta.total_pages ?? data.meta.pages ?? 1)}
-                  className="btn-secondary py-1 px-3 disabled:opacity-40"
                 >
                   次へ
-                </button>
+                </Button>
               </div>
             </div>
           )}
-        </div>
+        </Card>
       )}
 
       {/* Create Modal */}
@@ -242,10 +248,8 @@ function CreateProjectModal({
               className="block w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-primary-500 focus:border-primary-500" />
           </div>
           <div className="flex gap-3 justify-end pt-2">
-            <button type="button" onClick={onClose} className="btn-secondary">キャンセル</button>
-            <button type="submit" disabled={loading} className="btn-primary disabled:opacity-60">
-              {loading ? "保存中..." : "作成"}
-            </button>
+            <Button type="button" variant="secondary" onClick={onClose}>キャンセル</Button>
+            <Button type="submit" loading={loading}>作成</Button>
           </div>
         </form>
       </div>

--- a/frontend/src/pages/reports/DailyReportsPage.tsx
+++ b/frontend/src/pages/reports/DailyReportsPage.tsx
@@ -3,6 +3,7 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { FileText, Plus, CloudSun, X, ChevronDown, ChevronUp } from "lucide-react";
 import { dailyReportsApi, DailyReport, DailyReportCreate } from "@/api/daily_reports";
 import { projectsApi } from "@/api/projects";
+import { Badge, Button, Card, Skeleton } from "@/components/ui";
 
 const WEATHER_OPTIONS = [
   { value: "SUNNY", label: "晴れ ☀️" },
@@ -30,13 +31,16 @@ const STATUS_LABEL: Record<string, string> = {
   SUBMITTED: "提出済",
   APPROVED: "承認済",
 };
-const STATUS_BADGE: Record<string, string> = {
-  draft: "badge-secondary",
-  DRAFT: "badge-secondary",
-  submitted: "badge-info",
-  SUBMITTED: "badge-info",
-  approved: "badge-success",
-  APPROVED: "badge-success",
+
+type BadgeVariant = "default" | "info" | "success";
+
+const STATUS_VARIANT: Record<string, BadgeVariant> = {
+  draft: "default",
+  DRAFT: "default",
+  submitted: "info",
+  SUBMITTED: "info",
+  approved: "success",
+  APPROVED: "success",
 };
 
 interface FormState extends DailyReportCreate {
@@ -169,17 +173,16 @@ export default function DailyReportsPage() {
           <FileText className="w-7 h-7 text-primary-600" />
           日報管理
         </h2>
-        <button
-          className="btn-primary"
+        <Button
+          leftIcon={<Plus className="w-4 h-4" />}
           onClick={openModal}
           disabled={!selectedProjectId}
         >
-          <Plus className="w-4 h-4 mr-1" />
           新規日報作成
-        </button>
+        </Button>
       </div>
 
-      <div className="card">
+      <Card>
         <label className="block text-sm font-medium text-gray-700 mb-1">
           プロジェクト選択
         </label>
@@ -195,7 +198,7 @@ export default function DailyReportsPage() {
             </option>
           ))}
         </select>
-      </div>
+      </Card>
 
       {error && (
         <div className="bg-red-50 border border-red-300 text-red-700 px-4 py-3 rounded">
@@ -204,20 +207,22 @@ export default function DailyReportsPage() {
       )}
 
       {!selectedProjectId ? (
-        <div className="card text-center py-16 text-gray-400">
+        <Card className="text-center py-16 text-gray-400">
           <FileText className="w-12 h-12 mx-auto mb-3" />
           <p className="text-lg font-medium">プロジェクトを選択してください</p>
-        </div>
+        </Card>
       ) : isLoading ? (
-        <div className="card text-center py-16 text-gray-400">読み込み中...</div>
+        <Card className="space-y-3">
+          {[...Array(4)].map((_, i) => <Skeleton key={i} className="h-12 w-full" />)}
+        </Card>
       ) : reports.length === 0 ? (
-        <div className="card text-center py-16 text-gray-400">
+        <Card className="text-center py-16 text-gray-400">
           <CloudSun className="w-12 h-12 mx-auto mb-3" />
           <p className="text-lg font-medium">日報がまだありません</p>
           <p className="text-sm mt-1">「新規日報作成」から追加してください</p>
-        </div>
+        </Card>
       ) : (
-        <div className="card p-0 overflow-hidden">
+        <Card padding="none" className="overflow-hidden">
           <table className="w-full text-sm">
             <thead className="bg-gray-50 border-b border-gray-200">
               <tr>
@@ -253,15 +258,15 @@ export default function DailyReportsPage() {
                       </td>
                       <td className="px-4 py-3">
                         {r.safety_check ? (
-                          <span className="badge-success">確認済</span>
+                          <Badge variant="success" size="sm">確認済</Badge>
                         ) : (
-                          <span className="badge-danger">未確認</span>
+                          <Badge variant="danger" size="sm">未確認</Badge>
                         )}
                       </td>
                       <td className="px-4 py-3">
-                        <span className={STATUS_BADGE[r.status] ?? "badge-info"}>
+                        <Badge variant={STATUS_VARIANT[r.status] ?? "info"} size="sm">
                           {STATUS_LABEL[r.status] ?? r.status}
-                        </span>
+                        </Badge>
                       </td>
                       <td className="px-4 py-3 text-gray-400">
                         {isExpanded ? <ChevronUp className="w-4 h-4" /> : <ChevronDown className="w-4 h-4" />}
@@ -313,7 +318,7 @@ export default function DailyReportsPage() {
               })}
             </tbody>
           </table>
-        </div>
+        </Card>
       )}
 
       {showModal && (
@@ -420,12 +425,12 @@ export default function DailyReportsPage() {
                 <p className="text-red-600 text-sm">作成に失敗しました。</p>
               )}
               <div className="flex justify-end gap-3 pt-2">
-                <button type="button" className="btn-secondary" onClick={() => setShowModal(false)}>
+                <Button type="button" variant="secondary" onClick={() => setShowModal(false)}>
                   キャンセル
-                </button>
-                <button type="submit" className="btn-primary" disabled={createMutation.isPending}>
-                  {createMutation.isPending ? "作成中..." : "作成"}
-                </button>
+                </Button>
+                <Button type="submit" loading={createMutation.isPending}>
+                  作成
+                </Button>
               </div>
             </form>
           </div>
@@ -536,12 +541,16 @@ export default function DailyReportsPage() {
                 <p className="text-red-600 text-sm">更新に失敗しました。</p>
               )}
               <div className="flex justify-end gap-3 pt-2">
-                <button type="button" className="btn-secondary" onClick={() => { setShowEditModal(false); setEditingReport(null); }}>
+                <Button
+                  type="button"
+                  variant="secondary"
+                  onClick={() => { setShowEditModal(false); setEditingReport(null); }}
+                >
                   キャンセル
-                </button>
-                <button type="submit" className="btn-primary" disabled={updateMutation.isPending}>
-                  {updateMutation.isPending ? "更新中..." : "更新"}
-                </button>
+                </Button>
+                <Button type="submit" loading={updateMutation.isPending}>
+                  更新
+                </Button>
               </div>
             </form>
           </div>

--- a/frontend/src/pages/safety/SafetyPage.tsx
+++ b/frontend/src/pages/safety/SafetyPage.tsx
@@ -7,6 +7,7 @@ import {
   QualityInspectionCreate,
 } from "@/api/safety";
 import { projectsApi } from "@/api/projects";
+import { Badge, Button, Card, Skeleton } from "@/components/ui";
 
 type Tab = "checks" | "inspections";
 
@@ -22,13 +23,15 @@ const CHECK_TYPE_LABEL: Record<string, string> = {
   MONTHLY: "月次",
 };
 
-const RESULT_BADGE: Record<string, string> = {
-  合格: "badge-success",
-  pass: "badge-success",
-  OK: "badge-success",
-  不合格: "badge-danger",
-  fail: "badge-danger",
-  NG: "badge-danger",
+type BadgeVariant = "success" | "danger" | "info";
+
+const RESULT_VARIANT: Record<string, BadgeVariant> = {
+  合格: "success",
+  pass: "success",
+  OK: "success",
+  不合格: "danger",
+  fail: "danger",
+  NG: "danger",
 };
 
 export default function SafetyPage() {
@@ -167,17 +170,16 @@ export default function SafetyPage() {
           <HardHat className="w-7 h-7 text-primary-600" />
           安全品質管理
         </h2>
-        <button
-          className="btn-primary"
+        <Button
+          leftIcon={<Plus className="w-4 h-4" />}
           onClick={openModal}
           disabled={!selectedProjectId}
         >
-          <Plus className="w-4 h-4 mr-1" />
           新規作成
-        </button>
+        </Button>
       </div>
 
-      <div className="card">
+      <Card>
         <label className="block text-sm font-medium text-gray-700 mb-1">プロジェクト選択</label>
         <select
           className="input w-64"
@@ -191,7 +193,7 @@ export default function SafetyPage() {
             </option>
           ))}
         </select>
-      </div>
+      </Card>
 
       <div className="flex gap-1 border-b border-gray-200">
         {(["checks", "inspections"] as Tab[]).map((t) => (
@@ -214,20 +216,22 @@ export default function SafetyPage() {
       </div>
 
       {!selectedProjectId ? (
-        <div className="card text-center py-16 text-gray-400">
+        <Card className="text-center py-16 text-gray-400">
           <HardHat className="w-12 h-12 mx-auto mb-3" />
           <p className="text-lg font-medium">プロジェクトを選択してください</p>
-        </div>
+        </Card>
       ) : isLoading ? (
-        <div className="card text-center py-16 text-gray-400">読み込み中...</div>
+        <Card className="space-y-3">
+          {[...Array(4)].map((_, i) => <Skeleton key={i} className="h-12 w-full" />)}
+        </Card>
       ) : tab === "checks" ? (
         checks.length === 0 ? (
-          <div className="card text-center py-16 text-gray-400">
+          <Card className="text-center py-16 text-gray-400">
             <CheckCircle className="w-12 h-12 mx-auto mb-3" />
             <p className="text-lg font-medium">安全チェックデータがありません</p>
-          </div>
+          </Card>
         ) : (
-          <div className="card p-0 overflow-hidden">
+          <Card padding="none" className="overflow-hidden">
             <table className="w-full text-sm">
               <thead className="bg-gray-50 border-b border-gray-200">
                 <tr>
@@ -249,16 +253,16 @@ export default function SafetyPage() {
                       >
                         <td className="px-4 py-3">{c.check_date}</td>
                         <td className="px-4 py-3">
-                          <span className="badge-info">
+                          <Badge variant="info" size="sm">
                             {CHECK_TYPE_LABEL[c.check_type] ?? c.check_type}
-                          </span>
+                          </Badge>
                         </td>
                         <td className="px-4 py-3 text-green-700 font-medium">{c.items_ok}</td>
                         <td className="px-4 py-3 text-red-600 font-medium">{c.items_ng}</td>
                         <td className="px-4 py-3">
-                          <span className={RESULT_BADGE[c.overall_result] ?? "badge-info"}>
+                          <Badge variant={RESULT_VARIANT[c.overall_result] ?? "info"} size="sm">
                             {c.overall_result}
-                          </span>
+                          </Badge>
                         </td>
                         <td className="px-4 py-3">
                           <button
@@ -308,15 +312,15 @@ export default function SafetyPage() {
                 })}
               </tbody>
             </table>
-          </div>
+          </Card>
         )
       ) : inspections.length === 0 ? (
-        <div className="card text-center py-16 text-gray-400">
+        <Card className="text-center py-16 text-gray-400">
           <FlaskConical className="w-12 h-12 mx-auto mb-3" />
           <p className="text-lg font-medium">品質検査データがありません</p>
-        </div>
+        </Card>
       ) : (
-        <div className="card p-0 overflow-hidden">
+        <Card padding="none" className="overflow-hidden">
           <table className="w-full text-sm">
             <thead className="bg-gray-50 border-b border-gray-200">
               <tr>
@@ -333,7 +337,9 @@ export default function SafetyPage() {
                   <td className="px-4 py-3">{i.target_item}</td>
                   <td className="px-4 py-3">{i.measured_value ?? "—"}</td>
                   <td className="px-4 py-3">
-                    <span className={RESULT_BADGE[i.result] ?? "badge-info"}>{i.result}</span>
+                    <Badge variant={RESULT_VARIANT[i.result] ?? "info"} size="sm">
+                      {i.result}
+                    </Badge>
                   </td>
                   <td className="px-4 py-3">
                     <button
@@ -348,7 +354,7 @@ export default function SafetyPage() {
               ))}
             </tbody>
           </table>
-        </div>
+        </Card>
       )}
 
       {showModal && (
@@ -451,12 +457,12 @@ export default function SafetyPage() {
               )}
               {isError && <p className="text-red-600 text-sm">作成に失敗しました。</p>}
               <div className="flex justify-end gap-3 pt-2">
-                <button type="button" className="btn-secondary" onClick={() => setShowModal(false)}>
+                <Button type="button" variant="secondary" onClick={() => setShowModal(false)}>
                   キャンセル
-                </button>
-                <button type="submit" className="btn-primary" disabled={isPending}>
-                  {isPending ? "作成中..." : "作成"}
-                </button>
+                </Button>
+                <Button type="submit" loading={isPending}>
+                  作成
+                </Button>
               </div>
             </form>
           </div>


### PR DESCRIPTION
## 変更内容

Projects / DailyReports / Safety / Cost の 4 ページで、CSS クラスベースの UI プリミティブを共通 React コンポーネントへ統一。

### 置き換え対象
| Before | After |
|---|---|
| `<span class="badge-info">` | `<Badge variant="info" size="sm">` |
| `<button class="btn-primary">` | `<Button loading={...}>` |
| `<button class="btn-secondary">` | `<Button variant="secondary">` |
| `<div class="card">` | `<Card>` / `<Card padding="none">` |
| ローディング `div` | `<Skeleton>` inside `<Card>` |
| インライン styled ボタン（CostPage テーブル行） | `<Button variant="ghost\|danger" size="sm">` |

### 影響ファイル
- `frontend/src/pages/projects/ProjectsPage.tsx`
- `frontend/src/pages/reports/DailyReportsPage.tsx`
- `frontend/src/pages/safety/SafetyPage.tsx`
- `frontend/src/pages/cost/CostPage.tsx`

## テスト結果

- `tsc --noEmit`: エラー 0
- `vite build`: ✓ built in 2.35s (1703 modules)

## 影響範囲

UI コンポーネントの内部実装変更のみ。API・状態管理・ルーティングへの変更なし。

## 残課題

- ESLint 設定ファイル未整備（ESLint v9 移行未対応 — 別 Issue で対応予定）
- E2E テストのフォーム操作・CRUD フロー拡充（Sprint 2 予定）

🤖 Generated with [Claude Code](https://claude.com/claude-code)