### PR TITLE
chore(ci): Node.js 20 → 22 移行 + lint の || true 除去

### DIFF
--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -22,11 +22,11 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
           cache: npm
           cache-dependency-path: frontend/package-lock.json
       - run: npm ci --legacy-peer-deps
-      - run: npm run lint || true
+      - run: npm run lint
       - run: npm run build
       - uses: actions/upload-artifact@v4
         with:
@@ -44,7 +44,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
           cache: npm
           cache-dependency-path: frontend/package-lock.json
       - run: npm ci --legacy-peer-deps
@@ -60,7 +60,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
           cache: npm
           cache-dependency-path: frontend/package-lock.json
       - run: npm ci --legacy-peer-deps


### PR DESCRIPTION
## 変更内容

- `ci-frontend.yml` の全3ジョブで `node-version: "20"` → `"22"` に変更
- `npm run lint || true` → `npm run lint` に修正（ESLint v9設定完備後はエラー隠蔽不要）

## 背景

| 項目 | 内容 |
|------|------|
| GitHub Actions Node.js 20 deprecation | 2026-06-02 期限 |
| `\|\| true` の問題 | CIがlintエラーを無視する設計不備 |
| ESLint v9 対応 | PR #49 で設定完備済み |

## テスト結果

| チェック | 状態 |
|----------|------|
| ローカル lint | ✅ 0 errors |
| ローカル build | ✅ 成功 |
| ローカル typecheck | ✅ 成功 |

## 影響範囲

- `.github/workflows/ci-frontend.yml` のみ
- ランタイム変更なし（CI実行環境のNodeバージョン変更）

## 残課題

- Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)