### PR TITLE
fix: Vite API プロキシをDocker Composeポート8888に修正

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -13,7 +13,11 @@ export default defineConfig({
     port: 3000,
     proxy: {
       "/api": {
-        target: "http://localhost:8000",
+        target: "http://localhost:8888",
+        changeOrigin: true,
+      },
+      "/health": {
+        target: "http://localhost:8888",
         changeOrigin: true,
       },
     },


### PR DESCRIPTION
## Summary

- Vite dev server (5173) の API プロキシ先を `localhost:8000` → `localhost:8888` に修正
- Docker Compose でマッピングされた API ポートに合わせた
- `/health` エンドポイントのプロキシも追加

## Test plan

- [x] `curl http://localhost:5173/api/v1/status` で API レスポンス確認
- [x] ブラウザからログイン可能

🤖 Generated with [Claude Code](https://claude.com/claude-code)