### PR TITLE
chore: DBシード修正 + CORS統一 + Node.js 24 Actions先行対応

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   lint:
     name: Lint & Format (ruff)

--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -11,6 +11,9 @@ on:
     paths:
       - "frontend/**"
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   lint-build:
     name: Lint & Build

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -8,6 +8,9 @@ on:
   schedule:
     - cron: "0 2 * * 1"  # 毎週月曜日 02:00 UTC
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   bandit:
     name: Python Security (bandit)

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -30,7 +30,12 @@ class Settings(BaseSettings):
     REFRESH_TOKEN_EXPIRE_DAYS: int = 7
 
     # CORS設定
-    ALLOWED_ORIGINS: list[str] = ["http://localhost:3000", "http://localhost:5173"]
+    ALLOWED_ORIGINS: list[str] = [
+        "http://localhost:3000",
+        "http://localhost:5173",
+        "http://localhost:7080",
+        "http://localhost:4173",
+    ]
 
     @field_validator("ALLOWED_ORIGINS", mode="before")
     @classmethod

--- a/backend/db/init/02_users.sql
+++ b/backend/db/init/02_users.sql
@@ -19,11 +19,16 @@ CREATE TRIGGER trg_users_updated_at
     BEFORE UPDATE ON users
     FOR EACH ROW EXECUTE FUNCTION update_updated_at();
 
--- 初期管理者ユーザー（パスワード: Admin1234! のbcryptハッシュ）
-INSERT INTO users (email, hashed_password, full_name, role)
-VALUES (
-    'admin@servicehub.local',
-    '$2b$12$LQv3c1yqBWVHxkd0LHAkCOYz6TtxMQJqhN8/LewdBPj4uq1CuYMW2',
-    'システム管理者',
-    'ADMIN'
-) ON CONFLICT (email) DO NOTHING;
+-- ============================================
+-- 初期デモユーザー（パスワード: Admin123!）
+-- bcrypt hash: $2b$12$HKXNvMoWrEQKvd9chifSq.9xJHiBQ9gpnnKFkXECW3u.4MWqwPwCS
+-- ============================================
+INSERT INTO users (email, hashed_password, full_name, role) VALUES
+    ('admin@example.com',      '$2b$12$HKXNvMoWrEQKvd9chifSq.9xJHiBQ9gpnnKFkXECW3u.4MWqwPwCS', 'システム管理者',  'ADMIN'),
+    ('pm@example.com',         '$2b$12$HKXNvMoWrEQKvd9chifSq.9xJHiBQ9gpnnKFkXECW3u.4MWqwPwCS', '工事部長 田中',    'PROJECT_MANAGER'),
+    ('supervisor@example.com', '$2b$12$HKXNvMoWrEQKvd9chifSq.9xJHiBQ9gpnnKFkXECW3u.4MWqwPwCS', '現場監督 鈴木',    'SITE_SUPERVISOR'),
+    ('cost@example.com',       '$2b$12$HKXNvMoWrEQKvd9chifSq.9xJHiBQ9gpnnKFkXECW3u.4MWqwPwCS', '原価管理 山田',    'COST_MANAGER'),
+    ('safety@example.com',     '$2b$12$HKXNvMoWrEQKvd9chifSq.9xJHiBQ9gpnnKFkXECW3u.4MWqwPwCS', '安全管理 高橋',    'SAFETY_OFFICER'),
+    ('itop@example.com',       '$2b$12$HKXNvMoWrEQKvd9chifSq.9xJHiBQ9gpnnKFkXECW3u.4MWqwPwCS', 'IT運用 佐藤',      'IT_OPERATOR'),
+    ('viewer@example.com',     '$2b$12$HKXNvMoWrEQKvd9chifSq.9xJHiBQ9gpnnKFkXECW3u.4MWqwPwCS', '閲覧ユーザー',    'VIEWER')
+ON CONFLICT (email) DO NOTHING;


### PR DESCRIPTION
## Summary

- **DBシード修正** — `.local` → `.example.com` ドメイン、全7ロールのデモユーザー登録
- **CORS設定統一** — 開発環境の全ポート（3000/5173/7080/4173）をカバー
- **Node.js 24 先行対応** — 全3ワークフローに `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true`

### デモユーザー一覧（パスワード: `Admin123!`）

| メール | ロール |
|:---|:---|
| `admin@example.com` | ADMIN |
| `pm@example.com` | PROJECT_MANAGER |
| `supervisor@example.com` | SITE_SUPERVISOR |
| `cost@example.com` | COST_MANAGER |
| `safety@example.com` | SAFETY_OFFICER |
| `itop@example.com` | IT_OPERATOR |
| `viewer@example.com` | VIEWER |

## Test plan

- [x] Backend ruff: all checks passed
- [x] Frontend vitest: 207 tests passed
- [ ] CI: Node.js 24 での動作確認（PR push 後に自動実行）

🤖 Generated with [Claude Code](https://claude.com/claude-code)