### PR TITLE
test(e2e): 日報・安全品質 CRUD E2E テスト追加

### DIFF
--- a/frontend/e2e/photos-crud.spec.ts
+++ b/frontend/e2e/photos-crud.spec.ts
@@ -1,0 +1,178 @@
+import { test, expect } from "@playwright/test";
+import { loginAndNavigate, MOCK_PHOTOS, MOCK_PROJECTS } from "./fixtures/api-mocks";
+
+const UPLOADED_PHOTO = {
+  id: "photo-new",
+  project_id: "1",
+  filename: "upload-test.jpg",
+  original_filename: "テスト写真.jpg",
+  file_size: 51200,
+  mime_type: "image/jpeg",
+  category: "GENERAL",
+  description: "アップロードテスト",
+  taken_at: "2026-04-15T09:00:00Z",
+  url: null,
+  created_at: "2026-04-15T09:00:00Z",
+};
+
+/** Set up photos page with mutable list supporting upload/delete mock responses. */
+async function setupPhotosCrudPage(page: import("@playwright/test").Page) {
+  await loginAndNavigate(page);
+
+  await page.route("**/api/v1/projects**", (route) => {
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        success: true,
+        data: MOCK_PROJECTS,
+        meta: { page: 1, per_page: 100, total: 2 },
+      }),
+    });
+  });
+
+  let photosList = [...MOCK_PHOTOS];
+
+  // DELETE route must be registered before the GET/POST route to avoid glob shadowing
+  await page.route("**/api/v1/projects/1/photos/*", (route) => {
+    const method = route.request().method();
+    if (method === "DELETE") {
+      const url = route.request().url();
+      photosList = photosList.filter((p) => !url.includes(p.id));
+      route.fulfill({ status: 204 });
+    } else {
+      // GET single photo
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ success: true, data: photosList[0] }),
+      });
+    }
+  });
+
+  await page.route("**/api/v1/projects/1/photos**", (route) => {
+    const method = route.request().method();
+    if (method === "POST") {
+      photosList = [UPLOADED_PHOTO, ...photosList];
+      route.fulfill({
+        status: 201,
+        contentType: "application/json",
+        body: JSON.stringify({ success: true, data: UPLOADED_PHOTO }),
+      });
+    } else {
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          success: true,
+          data: photosList,
+          meta: { total: photosList.length, page: 1, per_page: 20, pages: 1 },
+        }),
+      });
+    }
+  });
+
+  await page.getByRole("link", { name: "写真管理" }).click();
+  await page.waitForURL("**/photos");
+  await page.locator("select").first().selectOption("1");
+
+  // Wait for initial photos to load
+  await expect(page.getByText("2階部分の鉄骨組み立て完了")).toBeVisible({ timeout: 10_000 });
+}
+
+test.describe("Photos CRUD", () => {
+  test("uploads a photo via file input", async ({ page }) => {
+    await setupPhotosCrudPage(page);
+
+    // The file input is hidden inside a <label> wrapper — use force to bypass display:none
+    await page.locator('input[type="file"]').setInputFiles(
+      {
+        name: "テスト写真.jpg",
+        mimeType: "image/jpeg",
+        buffer: Buffer.from("fake-image-data"),
+      },
+      { force: true }
+    );
+
+    // After upload, the new photo's filename should appear in the grid
+    await expect(page.getByText("テスト写真.jpg")).toBeVisible({ timeout: 10_000 });
+  });
+
+  test("uploads a photo with a custom description", async ({ page }) => {
+    await setupPhotosCrudPage(page);
+
+    // Fill description field (has htmlFor="description-input")
+    await page.getByLabel("説明（任意）").fill("アップロードテスト");
+
+    // Trigger file upload
+    await page.locator('input[type="file"]').setInputFiles(
+      {
+        name: "テスト写真.jpg",
+        mimeType: "image/jpeg",
+        buffer: Buffer.from("fake-image-data"),
+      },
+      { force: true }
+    );
+
+    // Uploaded photo description should appear
+    await expect(page.getByText("アップロードテスト")).toBeVisible({ timeout: 10_000 });
+  });
+
+  test("deletes a photo via delete button", async ({ page }) => {
+    await setupPhotosCrudPage(page);
+
+    // Auto-accept the window.confirm() dialog
+    page.on("dialog", (dialog) => dialog.accept());
+
+    // The delete button is opacity-0 until hover; use force:true to click regardless
+    await page.getByRole("button", { name: "削除" }).first().click({ force: true });
+
+    // One photo is deleted — only the second photo should remain visible
+    await expect(page.getByText("2階部分の鉄骨組み立て完了")).not.toBeVisible({ timeout: 10_000 });
+    await expect(page.getByText("安全帯着用確認")).toBeVisible();
+  });
+
+  test("cancels photo deletion when confirm is dismissed", async ({ page }) => {
+    await setupPhotosCrudPage(page);
+
+    // Dismiss the confirm dialog
+    page.on("dialog", (dialog) => dialog.dismiss());
+
+    await page.getByRole("button", { name: "削除" }).first().click({ force: true });
+
+    // Both photos should still be present after cancellation
+    await expect(page.getByText("2階部分の鉄骨組み立て完了")).toBeVisible({ timeout: 5_000 });
+    await expect(page.getByText("安全帯着用確認")).toBeVisible();
+  });
+
+  test("shows upload section with category selector and file button", async ({ page }) => {
+    await setupPhotosCrudPage(page);
+
+    await expect(page.getByText("📤 写真アップロード")).toBeVisible({ timeout: 10_000 });
+    // Category selector has htmlFor="category-select"
+    await expect(page.getByLabel("カテゴリ")).toBeVisible();
+    // Description input has htmlFor="description-input"
+    await expect(page.getByLabel("説明（任意）")).toBeVisible();
+    // File select button text (wrapped in <label>, pointer-events-none)
+    await expect(page.getByText("ファイル選択")).toBeVisible();
+  });
+
+  test("changes upload category before uploading", async ({ page }) => {
+    await setupPhotosCrudPage(page);
+
+    // Switch category to SAFETY
+    await page.getByLabel("カテゴリ").selectOption("SAFETY");
+
+    await page.locator('input[type="file"]').setInputFiles(
+      {
+        name: "テスト写真.jpg",
+        mimeType: "image/jpeg",
+        buffer: Buffer.from("fake-image-data"),
+      },
+      { force: true }
+    );
+
+    // Uploaded photo appears (category is handled server-side; verify filename)
+    await expect(page.getByText("テスト写真.jpg")).toBeVisible({ timeout: 10_000 });
+  });
+});

--- a/frontend/e2e/reports-crud.spec.ts
+++ b/frontend/e2e/reports-crud.spec.ts
@@ -1,0 +1,247 @@
+import { test, expect } from "@playwright/test";
+import { loginAndNavigate, MOCK_PROJECTS } from "./fixtures/api-mocks";
+
+const BASE_REPORTS = [
+  {
+    id: "rep-1",
+    project_id: "1",
+    report_date: "2026-04-10",
+    weather: "SUNNY",
+    worker_count: 12,
+    progress_rate: 65,
+    safety_check: true,
+    work_content: "2階スラブ配筋作業",
+    safety_notes: "安全帯着用確認済み",
+    issues: null,
+    status: "SUBMITTED",
+    author_id: 1,
+    created_at: "2026-04-10T09:00:00Z",
+    updated_at: "2026-04-10T09:00:00Z",
+  },
+  {
+    id: "rep-2",
+    project_id: "1",
+    report_date: "2026-04-09",
+    weather: "CLOUDY",
+    worker_count: 10,
+    progress_rate: 60,
+    safety_check: true,
+    work_content: "基礎コンクリート打設",
+    safety_notes: null,
+    issues: null,
+    status: "APPROVED",
+    author_id: 1,
+    created_at: "2026-04-09T09:00:00Z",
+    updated_at: "2026-04-09T10:00:00Z",
+  },
+];
+
+const CREATED_REPORT = {
+  id: "rep-new",
+  project_id: "1",
+  report_date: "2026-04-15",
+  weather: "RAINY",
+  worker_count: 8,
+  progress_rate: 70,
+  safety_check: true,
+  work_content: "E2Eテスト作業",
+  safety_notes: null,
+  issues: null,
+  status: "DRAFT",
+  author_id: 1,
+  created_at: "2026-04-15T09:00:00Z",
+  updated_at: "2026-04-15T09:00:00Z",
+};
+
+/** Set up reports page with mutable list supporting CRUD mock responses. */
+async function setupCrudPage(page: import("@playwright/test").Page) {
+  await loginAndNavigate(page);
+
+  await page.route("**/api/v1/projects**", (route) => {
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        success: true,
+        data: MOCK_PROJECTS,
+        meta: { page: 1, per_page: 100, total: 2 },
+      }),
+    });
+  });
+
+  // Mutable list to simulate server-side state changes
+  let reportsList = [...BASE_REPORTS];
+
+  await page.route("**/api/v1/projects/1/daily-reports**", (route) => {
+    const method = route.request().method();
+
+    if (method === "POST") {
+      reportsList = [CREATED_REPORT, ...reportsList];
+      route.fulfill({
+        status: 201,
+        contentType: "application/json",
+        body: JSON.stringify({ success: true, data: CREATED_REPORT }),
+      });
+    } else if (method === "DELETE") {
+      reportsList = reportsList.filter((r) => !route.request().url().includes(r.id));
+      route.fulfill({ status: 204 });
+    } else if (method === "PUT" || method === "PATCH") {
+      const updated = { ...BASE_REPORTS[0], work_content: "更新済み作業内容" };
+      reportsList = reportsList.map((r) => (r.id === "rep-1" ? updated : r));
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ success: true, data: updated }),
+      });
+    } else {
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          success: true,
+          data: reportsList,
+          meta: { total: reportsList.length, page: 1, per_page: 20 },
+        }),
+      });
+    }
+  });
+
+  await page.getByRole("link", { name: "日報", exact: true }).click();
+  await page.waitForURL("**/reports");
+  await page.locator("select").first().selectOption("1");
+
+  // Wait for initial list to load
+  await expect(page.getByText("2026-04-10")).toBeVisible({ timeout: 10_000 });
+}
+
+test.describe("Daily Reports CRUD", () => {
+  test("creates a new daily report via modal", async ({ page }) => {
+    await setupCrudPage(page);
+
+    await page.getByRole("button", { name: "新規日報作成" }).click();
+    await expect(
+      page.getByRole("heading", { name: "新規日報作成" })
+    ).toBeVisible({ timeout: 10_000 });
+
+    // Fill form fields using CSS selectors scoped to the modal overlay
+    const modal = page.locator("div.fixed.inset-0");
+    await modal.locator('input[type="date"]').fill("2026-04-15");
+    await modal.locator("select").first().selectOption("RAINY");
+
+    // Submit
+    await modal.getByRole("button", { name: "作成" }).click();
+
+    // Modal should close after successful creation
+    await expect(
+      page.getByRole("heading", { name: "新規日報作成" })
+    ).not.toBeVisible({ timeout: 10_000 });
+  });
+
+  test("cancels report creation without creating a report", async ({ page }) => {
+    await setupCrudPage(page);
+
+    await page.getByRole("button", { name: "新規日報作成" }).click();
+    await expect(
+      page.getByRole("heading", { name: "新規日報作成" })
+    ).toBeVisible({ timeout: 10_000 });
+
+    // Cancel
+    await page.locator("div.fixed.inset-0").getByRole("button", { name: "キャンセル" }).click();
+
+    // Modal should close
+    await expect(
+      page.getByRole("heading", { name: "新規日報作成" })
+    ).not.toBeVisible({ timeout: 5_000 });
+  });
+
+  test("edits a report via row expand and edit modal", async ({ page }) => {
+    await setupCrudPage(page);
+
+    // Click the first row to expand it
+    await page.getByText("2026-04-10").click();
+
+    // Edit button becomes visible inside expanded row
+    await expect(
+      page.getByRole("button", { name: "編集" }).first()
+    ).toBeVisible({ timeout: 10_000 });
+
+    await page.getByRole("button", { name: "編集" }).first().click();
+    await expect(
+      page.getByRole("heading", { name: "日報編集" })
+    ).toBeVisible({ timeout: 10_000 });
+
+    // Modify worker count in edit modal
+    const modal = page.locator("div.fixed.inset-0");
+    const workerInput = modal.locator('input[type="number"]').first();
+    await workerInput.fill("15");
+
+    // Submit update
+    await modal.getByRole("button", { name: "更新" }).click();
+
+    // Edit modal should close
+    await expect(
+      page.getByRole("heading", { name: "日報編集" })
+    ).not.toBeVisible({ timeout: 10_000 });
+  });
+
+  test("cancels report edit without saving", async ({ page }) => {
+    await setupCrudPage(page);
+
+    // Expand first row and open edit modal
+    await page.getByText("2026-04-10").click();
+    await expect(
+      page.getByRole("button", { name: "編集" }).first()
+    ).toBeVisible({ timeout: 10_000 });
+    await page.getByRole("button", { name: "編集" }).first().click();
+    await expect(
+      page.getByRole("heading", { name: "日報編集" })
+    ).toBeVisible({ timeout: 10_000 });
+
+    // Cancel
+    await page.locator("div.fixed.inset-0").getByRole("button", { name: "キャンセル" }).click();
+
+    // Edit modal should close
+    await expect(
+      page.getByRole("heading", { name: "日報編集" })
+    ).not.toBeVisible({ timeout: 5_000 });
+  });
+
+  test("deletes a report via row expand and delete button", async ({ page }) => {
+    await setupCrudPage(page);
+
+    // Auto-accept the confirm() dialog that appears on delete
+    page.on("dialog", (dialog) => dialog.accept());
+
+    // Click first row to expand
+    await page.getByText("2026-04-10").click();
+
+    // Delete button is visible inside expanded row
+    await expect(
+      page.getByRole("button", { name: "削除" }).first()
+    ).toBeVisible({ timeout: 10_000 });
+
+    await page.getByRole("button", { name: "削除" }).first().click();
+
+    // After deletion the list re-fetches; deleted row should eventually vanish
+    await expect(
+      page.getByRole("button", { name: "削除" }).first()
+    ).not.toBeVisible({ timeout: 10_000 });
+  });
+
+  test("shows create form with correct initial fields", async ({ page }) => {
+    await setupCrudPage(page);
+
+    await page.getByRole("button", { name: "新規日報作成" }).click();
+    await expect(
+      page.getByRole("heading", { name: "新規日報作成" })
+    ).toBeVisible({ timeout: 10_000 });
+
+    // Verify key form elements exist
+    const modal = page.locator("div.fixed.inset-0");
+    await expect(modal.locator('input[type="date"]')).toBeVisible();
+    await expect(modal.locator("select").first()).toBeVisible();
+    await expect(modal.getByLabel("安全確認済")).toBeVisible();
+    await expect(modal.getByRole("button", { name: "作成" })).toBeVisible();
+    await expect(modal.getByRole("button", { name: "キャンセル" })).toBeVisible();
+  });
+});

--- a/frontend/e2e/reports-crud.spec.ts
+++ b/frontend/e2e/reports-crud.spec.ts
@@ -72,26 +72,40 @@ async function setupCrudPage(page: import("@playwright/test").Page) {
   // Mutable list to simulate server-side state changes
   let reportsList = [...BASE_REPORTS];
 
-  await page.route("**/api/v1/projects/1/daily-reports**", (route) => {
+  // Resource-level endpoints: PUT /daily-reports/{id} and DELETE /daily-reports/{id}
+  // (no project prefix — see frontend/src/api/daily_reports.ts)
+  await page.route("**/api/v1/daily-reports/**", (route) => {
     const method = route.request().method();
-
-    if (method === "POST") {
-      reportsList = [CREATED_REPORT, ...reportsList];
-      route.fulfill({
-        status: 201,
-        contentType: "application/json",
-        body: JSON.stringify({ success: true, data: CREATED_REPORT }),
-      });
-    } else if (method === "DELETE") {
-      reportsList = reportsList.filter((r) => !route.request().url().includes(r.id));
-      route.fulfill({ status: 204 });
-    } else if (method === "PUT" || method === "PATCH") {
+    if (method === "PUT" || method === "PATCH") {
       const updated = { ...BASE_REPORTS[0], work_content: "更新済み作業内容" };
       reportsList = reportsList.map((r) => (r.id === "rep-1" ? updated : r));
       route.fulfill({
         status: 200,
         contentType: "application/json",
         body: JSON.stringify({ success: true, data: updated }),
+      });
+    } else if (method === "DELETE") {
+      const url = route.request().url();
+      reportsList = reportsList.filter((r) => !url.includes(r.id));
+      route.fulfill({ status: 204 });
+    } else {
+      // GET single report
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ success: true, data: reportsList[0] }),
+      });
+    }
+  });
+
+  await page.route("**/api/v1/projects/1/daily-reports**", (route) => {
+    const method = route.request().method();
+    if (method === "POST") {
+      reportsList = [CREATED_REPORT, ...reportsList];
+      route.fulfill({
+        status: 201,
+        contentType: "application/json",
+        body: JSON.stringify({ success: true, data: CREATED_REPORT }),
       });
     } else {
       route.fulfill({

--- a/frontend/e2e/safety-crud.spec.ts
+++ b/frontend/e2e/safety-crud.spec.ts
@@ -1,0 +1,320 @@
+import { test, expect } from "@playwright/test";
+import { loginAndNavigate, MOCK_PROJECTS } from "./fixtures/api-mocks";
+
+const BASE_SAFETY_CHECKS = [
+  {
+    id: "sc-1",
+    project_id: "1",
+    check_date: "2026-04-10",
+    check_type: "DAILY",
+    items_total: 10,
+    items_ok: 9,
+    items_ng: 1,
+    overall_result: "合格",
+    notes: "軽微なNG項目あり、翌日フォロー",
+    created_at: "2026-04-10T09:00:00Z",
+  },
+  {
+    id: "sc-2",
+    project_id: "1",
+    check_date: "2026-04-09",
+    check_type: "WEEKLY",
+    items_total: 20,
+    items_ok: 20,
+    items_ng: 0,
+    overall_result: "合格",
+    notes: null,
+    created_at: "2026-04-09T09:00:00Z",
+  },
+];
+
+const CREATED_SAFETY_CHECK = {
+  id: "sc-new",
+  project_id: "1",
+  check_date: "2026-04-15",
+  check_type: "WEEKLY",
+  items_total: 15,
+  items_ok: 15,
+  items_ng: 0,
+  overall_result: "合格",
+  notes: null,
+  created_at: "2026-04-15T09:00:00Z",
+};
+
+const BASE_QUALITY_INSPECTIONS = [
+  {
+    id: "qi-1",
+    project_id: "1",
+    inspection_date: "2026-04-10",
+    inspection_type: "コンクリート強度",
+    target_item: "基礎コンクリート",
+    standard_value: "21N/mm²",
+    measured_value: "24N/mm²",
+    result: "合格",
+    created_at: "2026-04-10T10:00:00Z",
+  },
+];
+
+const CREATED_QUALITY_INSPECTION = {
+  id: "qi-new",
+  project_id: "1",
+  inspection_date: "2026-04-15",
+  inspection_type: "鉄筋径検査",
+  target_item: "1階柱配筋",
+  standard_value: "D22",
+  measured_value: "D22",
+  result: "合格",
+  created_at: "2026-04-15T10:00:00Z",
+};
+
+/** Set up safety page with mutable list supporting CRUD mock responses. */
+async function setupSafetyCrudPage(page: import("@playwright/test").Page) {
+  await loginAndNavigate(page);
+
+  await page.route("**/api/v1/projects**", (route) => {
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        success: true,
+        data: MOCK_PROJECTS,
+        meta: { page: 1, per_page: 100, total: 2 },
+      }),
+    });
+  });
+
+  let checksList = [...BASE_SAFETY_CHECKS];
+
+  await page.route("**/api/v1/projects/1/safety-checks**", (route) => {
+    const method = route.request().method();
+    if (method === "POST") {
+      checksList = [CREATED_SAFETY_CHECK, ...checksList];
+      route.fulfill({
+        status: 201,
+        contentType: "application/json",
+        body: JSON.stringify({ success: true, data: CREATED_SAFETY_CHECK }),
+      });
+    } else if (method === "DELETE") {
+      checksList = checksList.filter((c) => !route.request().url().includes(c.id));
+      route.fulfill({ status: 204 });
+    } else {
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          success: true,
+          data: checksList,
+          meta: { total: checksList.length, page: 1, per_page: 20 },
+        }),
+      });
+    }
+  });
+
+  let inspectionsList = [...BASE_QUALITY_INSPECTIONS];
+
+  await page.route("**/api/v1/projects/1/quality-inspections**", (route) => {
+    const method = route.request().method();
+    if (method === "POST") {
+      inspectionsList = [CREATED_QUALITY_INSPECTION, ...inspectionsList];
+      route.fulfill({
+        status: 201,
+        contentType: "application/json",
+        body: JSON.stringify({ success: true, data: CREATED_QUALITY_INSPECTION }),
+      });
+    } else if (method === "DELETE") {
+      inspectionsList = inspectionsList.filter(
+        (i) => !route.request().url().includes(i.id)
+      );
+      route.fulfill({ status: 204 });
+    } else {
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          success: true,
+          data: inspectionsList,
+          meta: { total: inspectionsList.length, page: 1, per_page: 20 },
+        }),
+      });
+    }
+  });
+
+  await page.getByRole("link", { name: "安全品質" }).click();
+  await page.waitForURL("**/safety");
+  await page.locator("select").first().selectOption("1");
+
+  // Wait for safety checks list (default tab) to load
+  await expect(page.getByText("2026-04-10")).toBeVisible({ timeout: 10_000 });
+}
+
+test.describe("Safety Checks CRUD", () => {
+  test("creates a new safety check via modal", async ({ page }) => {
+    await setupSafetyCrudPage(page);
+
+    await page.getByRole("button", { name: "新規作成" }).click();
+    await expect(
+      page.getByRole("heading", { name: "安全チェック新規作成" })
+    ).toBeVisible({ timeout: 10_000 });
+
+    // Fill check form fields
+    const modal = page.locator("div.fixed.inset-0");
+    await modal.locator('input[type="date"]').fill("2026-04-15");
+    // Select "週次" for check type
+    await modal.locator("select").first().selectOption("WEEKLY");
+
+    // Submit
+    await modal.getByRole("button", { name: "作成" }).click();
+
+    // Modal should close
+    await expect(
+      page.getByRole("heading", { name: "安全チェック新規作成" })
+    ).not.toBeVisible({ timeout: 10_000 });
+  });
+
+  test("cancels safety check creation", async ({ page }) => {
+    await setupSafetyCrudPage(page);
+
+    await page.getByRole("button", { name: "新規作成" }).click();
+    await expect(
+      page.getByRole("heading", { name: "安全チェック新規作成" })
+    ).toBeVisible({ timeout: 10_000 });
+
+    await page.locator("div.fixed.inset-0").getByRole("button", { name: "キャンセル" }).click();
+
+    await expect(
+      page.getByRole("heading", { name: "安全チェック新規作成" })
+    ).not.toBeVisible({ timeout: 5_000 });
+  });
+
+  test("deletes a safety check with confirm dialog", async ({ page }) => {
+    await setupSafetyCrudPage(page);
+
+    // Auto-accept the window.confirm() that appears on delete
+    page.on("dialog", (dialog) => dialog.accept());
+
+    // Delete button is directly in the table row (no row-expand needed)
+    await expect(
+      page.getByRole("button", { name: "削除" }).first()
+    ).toBeVisible({ timeout: 10_000 });
+
+    await page.getByRole("button", { name: "削除" }).first().click();
+
+    // After deletion, the list re-fetches; deleted row should eventually vanish
+    await expect(
+      page.getByRole("button", { name: "削除" }).first()
+    ).not.toBeVisible({ timeout: 10_000 });
+  });
+
+  test("shows create form with correct fields for safety check tab", async ({
+    page,
+  }) => {
+    await setupSafetyCrudPage(page);
+
+    await page.getByRole("button", { name: "新規作成" }).click();
+    await expect(
+      page.getByRole("heading", { name: "安全チェック新規作成" })
+    ).toBeVisible({ timeout: 10_000 });
+
+    const modal = page.locator("div.fixed.inset-0");
+    // Date, type select, number inputs, result select, notes textarea
+    await expect(modal.locator('input[type="date"]')).toBeVisible();
+    await expect(modal.locator("select").first()).toBeVisible();
+    await expect(modal.locator('input[type="number"]').first()).toBeVisible();
+    await expect(modal.getByRole("button", { name: "作成" })).toBeVisible();
+    await expect(modal.getByRole("button", { name: "キャンセル" })).toBeVisible();
+  });
+});
+
+test.describe("Quality Inspections CRUD", () => {
+  test("creates a new quality inspection via inspections tab", async ({
+    page,
+  }) => {
+    await setupSafetyCrudPage(page);
+
+    // Switch to inspections tab first, then open modal
+    await page.getByRole("button", { name: /品質検査/ }).click();
+    // Wait for inspections data to load
+    await expect(page.getByText("コンクリート強度")).toBeVisible({ timeout: 10_000 });
+
+    await page.getByRole("button", { name: "新規作成" }).click();
+    await expect(
+      page.getByRole("heading", { name: "品質検査新規作成" })
+    ).toBeVisible({ timeout: 10_000 });
+
+    // Fill inspection form
+    const modal = page.locator("div.fixed.inset-0");
+    await modal.locator('input[type="date"]').fill("2026-04-15");
+    // inspection_type (first text input after date)
+    await modal.locator('input[type="text"]').nth(0).fill("鉄筋径検査");
+    // target_item (second text input)
+    await modal.locator('input[type="text"]').nth(1).fill("1階柱配筋");
+
+    // Submit
+    await modal.getByRole("button", { name: "作成" }).click();
+
+    // Modal should close
+    await expect(
+      page.getByRole("heading", { name: "品質検査新規作成" })
+    ).not.toBeVisible({ timeout: 10_000 });
+  });
+
+  test("cancels quality inspection creation", async ({ page }) => {
+    await setupSafetyCrudPage(page);
+
+    await page.getByRole("button", { name: /品質検査/ }).click();
+    await expect(page.getByText("コンクリート強度")).toBeVisible({ timeout: 10_000 });
+
+    await page.getByRole("button", { name: "新規作成" }).click();
+    await expect(
+      page.getByRole("heading", { name: "品質検査新規作成" })
+    ).toBeVisible({ timeout: 10_000 });
+
+    await page.locator("div.fixed.inset-0").getByRole("button", { name: "キャンセル" }).click();
+
+    await expect(
+      page.getByRole("heading", { name: "品質検査新規作成" })
+    ).not.toBeVisible({ timeout: 5_000 });
+  });
+
+  test("deletes a quality inspection with confirm dialog", async ({ page }) => {
+    await setupSafetyCrudPage(page);
+
+    page.on("dialog", (dialog) => dialog.accept());
+
+    // Switch to inspections tab
+    await page.getByRole("button", { name: /品質検査/ }).click();
+    await expect(page.getByText("コンクリート強度")).toBeVisible({ timeout: 10_000 });
+
+    // Delete button is in the table row
+    await expect(
+      page.getByRole("button", { name: "削除" }).first()
+    ).toBeVisible({ timeout: 10_000 });
+
+    await page.getByRole("button", { name: "削除" }).first().click();
+
+    // After deletion the row should vanish
+    await expect(
+      page.getByText("コンクリート強度")
+    ).not.toBeVisible({ timeout: 10_000 });
+  });
+
+  test("shows create form with correct fields for inspection tab", async ({
+    page,
+  }) => {
+    await setupSafetyCrudPage(page);
+
+    await page.getByRole("button", { name: /品質検査/ }).click();
+    await expect(page.getByText("コンクリート強度")).toBeVisible({ timeout: 10_000 });
+
+    await page.getByRole("button", { name: "新規作成" }).click();
+    await expect(
+      page.getByRole("heading", { name: "品質検査新規作成" })
+    ).toBeVisible({ timeout: 10_000 });
+
+    const modal = page.locator("div.fixed.inset-0");
+    await expect(modal.locator('input[type="date"]')).toBeVisible();
+    await expect(modal.locator('input[type="text"]').first()).toBeVisible();
+    await expect(modal.getByRole("button", { name: "作成" })).toBeVisible();
+    await expect(modal.getByRole("button", { name: "キャンセル" })).toBeVisible();
+  });
+});

--- a/frontend/e2e/safety-crud.spec.ts
+++ b/frontend/e2e/safety-crud.spec.ts
@@ -199,10 +199,11 @@ test.describe("Safety Checks CRUD", () => {
 
     await page.getByRole("button", { name: "削除" }).first().click();
 
-    // After deletion, the list re-fetches; deleted row should eventually vanish
+    // After deletion, sc-1 (DAILY/2026-04-10) is gone; sc-2 (WEEKLY/2026-04-09) remains.
+    // Expect exactly one delete button remaining, not zero.
     await expect(
-      page.getByRole("button", { name: "削除" }).first()
-    ).not.toBeVisible({ timeout: 10_000 });
+      page.getByRole("button", { name: "削除" })
+    ).toHaveCount(1, { timeout: 10_000 });
   });
 
   test("shows create form with correct fields for safety check tab", async ({


### PR DESCRIPTION
## Summary

- `reports-crud.spec.ts`: DailyReportsPage の CRUD E2E 5テスト追加
  - 作成モーダルフロー（日付・天気入力 → 作成 → モーダル閉じる）
  - キャンセルで作成しない
  - 行展開 → 編集ボタン → 日報編集モーダル → 更新
  - 行展開 → 削除ボタン → `window.confirm()` 自動承認 → 行消去
  - モーダル初期フィールド確認

- `safety-crud.spec.ts`: SafetyPage の CRUD E2E 9テスト追加
  - 安全チェックタブ: 作成・キャンセル・削除（行直接削除）・フォーム確認
  - 品質検査タブ: タブ切替 → 作成・キャンセル・削除・フォーム確認
  - モーダルタイトルはタブに応じて動的変化（安全チェック新規作成 / 品質検査新規作成）

## Test plan

- [ ] CI E2E テスト (Playwright) 全 PASS 確認
- [ ] div-based モーダル: `getByRole("heading")` でモーダル開閉を検証
- [ ] `window.confirm()`: `page.on('dialog', d => d.accept())` で事前登録
- [ ] API モック: POST/DELETE/PUT を method で分岐、mutable list でリスト更新をシミュレート
- [ ] 行展開パターン（DailyReportsPage）と直接削除パターン（SafetyPage）を両方カバー

## 影響範囲

- 新規追加: `frontend/e2e/reports-crud.spec.ts`, `frontend/e2e/safety-crud.spec.ts`
- 既存コードへの変更なし

## 残課題

- `photos-crud.spec.ts` (写真管理 CRUD E2E) は次 PR で対応予定

🤖 Generated with [Claude Code](https://claude.com/claude-code)