### PR TITLE
feat(notifications): 通知設定管理 Phase 1 — preferences CRUD 基盤 (Issue #91)

### DIFF
--- a/backend/alembic/versions/0008_notification_preferences.py
+++ b/backend/alembic/versions/0008_notification_preferences.py
@@ -1,0 +1,69 @@
+"""Notification preferences table
+
+Revision ID: 0008
+Revises: 0007
+Create Date: 2026-04-10
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "0008"
+down_revision = "0007"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "notification_preferences",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column(
+            "user_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+            unique=True,
+        ),
+        sa.Column(
+            "email_enabled", sa.Boolean, nullable=False, server_default=sa.true()
+        ),
+        sa.Column(
+            "slack_enabled", sa.Boolean, nullable=False, server_default=sa.false()
+        ),
+        sa.Column("slack_webhook_url", sa.String(500), nullable=True),
+        sa.Column(
+            "events",
+            postgresql.JSONB,
+            nullable=False,
+            server_default=sa.text("'{}'::jsonb"),
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+    )
+    op.create_index(
+        "ix_notification_preferences_user_id",
+        "notification_preferences",
+        ["user_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_notification_preferences_user_id", "notification_preferences")
+    op.drop_table("notification_preferences")

--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -9,6 +9,7 @@ from app.api.v1.routers import (
     dashboard,
     itsm,
     knowledge,
+    notification_preferences,
     photos,
     projects,
     safety,
@@ -27,3 +28,4 @@ api_router.include_router(itsm.router)
 api_router.include_router(knowledge.router)
 api_router.include_router(users.router)
 api_router.include_router(dashboard.router)
+api_router.include_router(notification_preferences.router)

--- a/backend/app/api/v1/routers/notification_preferences.py
+++ b/backend/app/api/v1/routers/notification_preferences.py
@@ -1,0 +1,48 @@
+"""通知設定 API ルーター（自ユーザーのみアクセス可）
+
+GET   /api/v1/users/me/notification-preferences
+PATCH /api/v1/users/me/notification-preferences
+"""
+
+from typing import Annotated
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.v1.deps import get_current_user
+from app.db.base import get_db
+from app.models.user import User
+from app.schemas.common import ApiResponse
+from app.schemas.notification_preference import (
+    NotificationPreferenceResponse,
+    NotificationPreferenceUpdate,
+)
+from app.services.notification_preference_service import (
+    NotificationPreferenceService,
+)
+
+router = APIRouter(
+    prefix="/users/me/notification-preferences",
+    tags=["通知設定"],
+)
+
+
+@router.get("", response_model=ApiResponse[NotificationPreferenceResponse])
+async def get_my_notification_preferences(
+    db: Annotated[AsyncSession, Depends(get_db)],
+    current_user: Annotated[User, Depends(get_current_user)],
+):
+    svc = NotificationPreferenceService(db)
+    pref = await svc.get_or_create(current_user.id)
+    return ApiResponse(data=pref)
+
+
+@router.patch("", response_model=ApiResponse[NotificationPreferenceResponse])
+async def update_my_notification_preferences(
+    payload: NotificationPreferenceUpdate,
+    db: Annotated[AsyncSession, Depends(get_db)],
+    current_user: Annotated[User, Depends(get_current_user)],
+):
+    svc = NotificationPreferenceService(db)
+    pref = await svc.update_preferences(current_user.id, payload)
+    return ApiResponse(data=pref)

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -5,6 +5,7 @@ from app.models.cost import CostRecord, WorkHour
 from app.models.daily_report import DailyReport
 from app.models.itsm import ChangeRequest, Incident
 from app.models.knowledge import AiSearchLog, KnowledgeArticle
+from app.models.notification_preference import NotificationPreference
 from app.models.photo import Photo
 from app.models.project import Project
 from app.models.safety import QualityInspection, SafetyCheck
@@ -24,4 +25,5 @@ __all__ = [
     "ChangeRequest",
     "KnowledgeArticle",
     "AiSearchLog",
+    "NotificationPreference",
 ]

--- a/backend/app/models/notification_preference.py
+++ b/backend/app/models/notification_preference.py
@@ -1,0 +1,51 @@
+"""通知設定モデル（SQLAlchemy）
+
+ユーザーごとの通知購読設定を保持する。1 ユーザー = 1 レコード。
+events カラムはイベント種別 × チャンネルの購読可否を JSON で管理する。
+"""
+
+import uuid
+from datetime import datetime
+from typing import Any
+
+from sqlalchemy import JSON, Boolean, DateTime, ForeignKey, String, Uuid, func
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db.base import Base
+
+
+class NotificationPreference(Base):
+    __tablename__ = "notification_preferences"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        Uuid(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        Uuid(as_uuid=True),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        unique=True,
+        index=True,
+    )
+    email_enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+    slack_enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    slack_webhook_url: Mapped[str | None] = mapped_column(String(500), nullable=True)
+    # JSON (not JSONB) for SQLite test DB compatibility; PostgreSQL migration
+    # uses JSONB for better performance in production.
+    events: Mapped[dict[str, Any]] = mapped_column(JSON, nullable=False, default=dict)
+
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )
+
+    def __repr__(self) -> str:
+        return (
+            f"<NotificationPreference id={self.id} user_id={self.user_id} "
+            f"email={self.email_enabled} slack={self.slack_enabled}>"
+        )

--- a/backend/app/repositories/notification_preference.py
+++ b/backend/app/repositories/notification_preference.py
@@ -1,0 +1,53 @@
+"""通知設定リポジトリ（DB 操作レイヤー）"""
+
+import uuid
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.notification_preference import NotificationPreference
+
+
+class NotificationPreferenceRepository:
+    def __init__(self, db: AsyncSession):
+        self.db = db
+
+    async def get_by_user_id(self, user_id: uuid.UUID) -> NotificationPreference | None:
+        result = await self.db.execute(
+            select(NotificationPreference).where(
+                NotificationPreference.user_id == user_id
+            )
+        )
+        return result.scalar_one_or_none()
+
+    async def create(
+        self,
+        user_id: uuid.UUID,
+        email_enabled: bool = True,
+        slack_enabled: bool = False,
+        slack_webhook_url: str | None = None,
+        events: dict[str, Any] | None = None,
+    ) -> NotificationPreference:
+        pref = NotificationPreference(
+            user_id=user_id,
+            email_enabled=email_enabled,
+            slack_enabled=slack_enabled,
+            slack_webhook_url=slack_webhook_url,
+            events=events or {},
+        )
+        self.db.add(pref)
+        await self.db.flush()
+        await self.db.refresh(pref)
+        return pref
+
+    async def update(
+        self,
+        pref: NotificationPreference,
+        data: dict[str, Any],
+    ) -> NotificationPreference:
+        for field, value in data.items():
+            setattr(pref, field, value)
+        await self.db.flush()
+        await self.db.refresh(pref)
+        return pref

--- a/backend/app/schemas/notification_preference.py
+++ b/backend/app/schemas/notification_preference.py
@@ -1,0 +1,31 @@
+"""通知設定スキーマ（Pydantic v2）"""
+
+from typing import Any
+
+from pydantic import BaseModel, Field, HttpUrl
+
+
+class NotificationPreferenceResponse(BaseModel):
+    """通知設定レスポンス"""
+
+    email_enabled: bool
+    slack_enabled: bool
+    slack_webhook_url: str | None
+    events: dict[str, Any]
+
+    model_config = {"from_attributes": True}
+
+
+class NotificationPreferenceUpdate(BaseModel):
+    """通知設定更新（部分更新）"""
+
+    email_enabled: bool | None = None
+    slack_enabled: bool | None = None
+    slack_webhook_url: HttpUrl | None = Field(
+        default=None,
+        description="Slack Incoming Webhook URL",
+    )
+    events: dict[str, Any] | None = Field(
+        default=None,
+        description="イベント種別ごとの購読設定（完全置換）",
+    )

--- a/backend/app/services/notification_preference_service.py
+++ b/backend/app/services/notification_preference_service.py
@@ -1,0 +1,80 @@
+"""通知設定サービス（ビジネスロジック層）
+
+upsert-on-read の方針により、GET 時にレコードが存在しなければデフォルト値で
+自動生成する。これによりフロントエンドは常にデフォルト設定を取得でき、
+「レコード未作成」という 404 状態を意識しなくて済む。
+"""
+
+import uuid
+from typing import Any
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.repositories.notification_preference import (
+    NotificationPreferenceRepository,
+)
+from app.schemas.notification_preference import (
+    NotificationPreferenceResponse,
+    NotificationPreferenceUpdate,
+)
+
+# デフォルト購読イベント。新規ユーザーの初期設定として使用する。
+DEFAULT_EVENTS: dict[str, Any] = {
+    "daily_report_submitted": {"email": True, "slack": False},
+    "safety_incident_created": {"email": True, "slack": True},
+    "change_request_pending_approval": {"email": True, "slack": False},
+    "incident_assigned": {"email": True, "slack": False},
+    "project_status_changed": {"email": False, "slack": False},
+}
+
+
+class NotificationPreferenceService:
+    def __init__(self, db: AsyncSession):
+        self.db = db
+        self.repo = NotificationPreferenceRepository(db)
+
+    async def get_or_create(self, user_id: uuid.UUID) -> NotificationPreferenceResponse:
+        """Upsert-on-read: レコードが無ければデフォルト値で作成して返す。"""
+        pref = await self.repo.get_by_user_id(user_id)
+        if pref is None:
+            pref = await self.repo.create(
+                user_id=user_id,
+                events=DEFAULT_EVENTS.copy(),
+            )
+        return NotificationPreferenceResponse.model_validate(pref)
+
+    async def update_preferences(
+        self,
+        user_id: uuid.UUID,
+        data: NotificationPreferenceUpdate,
+    ) -> NotificationPreferenceResponse:
+        """部分更新。レコードが無い場合は先にデフォルト値で作成する。"""
+        pref = await self.repo.get_by_user_id(user_id)
+        if pref is None:
+            pref = await self.repo.create(
+                user_id=user_id,
+                events=DEFAULT_EVENTS.copy(),
+            )
+        update_data = self._build_update_dict(data)
+        if update_data:
+            pref = await self.repo.update(pref, update_data)
+        return NotificationPreferenceResponse.model_validate(pref)
+
+    @staticmethod
+    def _build_update_dict(
+        data: NotificationPreferenceUpdate,
+    ) -> dict[str, Any]:
+        """Pydantic モデルから None 以外のフィールドのみを取り出す。
+
+        HttpUrl 型は文字列に変換する必要がある。
+        """
+        result: dict[str, Any] = {}
+        if data.email_enabled is not None:
+            result["email_enabled"] = data.email_enabled
+        if data.slack_enabled is not None:
+            result["slack_enabled"] = data.slack_enabled
+        if data.slack_webhook_url is not None:
+            result["slack_webhook_url"] = str(data.slack_webhook_url)
+        if data.events is not None:
+            result["events"] = data.events
+        return result

--- a/backend/tests/integration/test_notification_preferences_integration.py
+++ b/backend/tests/integration/test_notification_preferences_integration.py
@@ -1,0 +1,122 @@
+"""通知設定 API 統合テスト"""
+
+from __future__ import annotations
+
+import pytest
+from httpx import AsyncClient
+
+
+@pytest.mark.asyncio
+async def test_get_preferences_creates_default(
+    auth_client: AsyncClient, admin_headers: dict
+):
+    """初回 GET でデフォルト値が返る"""
+    resp = await auth_client.get(
+        "/api/v1/users/me/notification-preferences",
+        headers=admin_headers,
+    )
+    assert resp.status_code == 200, resp.text
+    data = resp.json()["data"]
+    assert data["email_enabled"] is True
+    assert data["slack_enabled"] is False
+    assert data["slack_webhook_url"] is None
+    assert "daily_report_submitted" in data["events"]
+
+
+@pytest.mark.asyncio
+async def test_get_preferences_requires_auth(auth_client: AsyncClient):
+    """認証必須: トークン無しは 401"""
+    resp = await auth_client.get("/api/v1/users/me/notification-preferences")
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_patch_preferences_partial_update(
+    auth_client: AsyncClient, admin_headers: dict
+):
+    """部分更新: email_enabled のみ変更"""
+    # 初期状態を作成
+    await auth_client.get(
+        "/api/v1/users/me/notification-preferences", headers=admin_headers
+    )
+
+    resp = await auth_client.patch(
+        "/api/v1/users/me/notification-preferences",
+        json={"email_enabled": False},
+        headers=admin_headers,
+    )
+    assert resp.status_code == 200, resp.text
+    data = resp.json()["data"]
+    assert data["email_enabled"] is False
+    assert data["slack_enabled"] is False
+
+
+@pytest.mark.asyncio
+async def test_patch_preferences_with_slack_webhook(
+    auth_client: AsyncClient, admin_headers: dict
+):
+    """Slack Webhook URL の設定"""
+    webhook = "https://example.com/webhook/slack-integration"
+    resp = await auth_client.patch(
+        "/api/v1/users/me/notification-preferences",
+        json={
+            "slack_enabled": True,
+            "slack_webhook_url": webhook,
+        },
+        headers=admin_headers,
+    )
+    assert resp.status_code == 200, resp.text
+    data = resp.json()["data"]
+    assert data["slack_enabled"] is True
+    assert data["slack_webhook_url"] == webhook
+
+
+@pytest.mark.asyncio
+async def test_patch_preferences_events_full_replace(
+    auth_client: AsyncClient, admin_headers: dict
+):
+    """events は完全置換される"""
+    new_events = {
+        "daily_report_submitted": {"email": False, "slack": True},
+    }
+    resp = await auth_client.patch(
+        "/api/v1/users/me/notification-preferences",
+        json={"events": new_events},
+        headers=admin_headers,
+    )
+    assert resp.status_code == 200, resp.text
+    data = resp.json()["data"]
+    assert data["events"] == new_events
+
+
+@pytest.mark.asyncio
+async def test_patch_preferences_invalid_webhook_url(
+    auth_client: AsyncClient, admin_headers: dict
+):
+    """不正な Webhook URL はバリデーションエラー"""
+    resp = await auth_client.patch(
+        "/api/v1/users/me/notification-preferences",
+        json={"slack_webhook_url": "not-a-valid-url"},
+        headers=admin_headers,
+    )
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_preferences_isolated_per_user(
+    auth_client: AsyncClient, admin_headers: dict, pm_headers: dict
+):
+    """各ユーザーの設定は独立"""
+    # admin が email OFF
+    await auth_client.patch(
+        "/api/v1/users/me/notification-preferences",
+        json={"email_enabled": False},
+        headers=admin_headers,
+    )
+    # pm は影響を受けない
+    resp = await auth_client.get(
+        "/api/v1/users/me/notification-preferences",
+        headers=pm_headers,
+    )
+    assert resp.status_code == 200
+    assert resp.json()["data"]["email_enabled"] is True

--- a/backend/tests/unit/test_notification_preference_service.py
+++ b/backend/tests/unit/test_notification_preference_service.py
@@ -1,0 +1,115 @@
+"""NotificationPreferenceService のユニットテスト"""
+
+import pytest
+
+from app.schemas.notification_preference import NotificationPreferenceUpdate
+from app.services.notification_preference_service import (
+    DEFAULT_EVENTS,
+    NotificationPreferenceService,
+)
+from tests.conftest import ADMIN_USER_ID, VIEWER_USER_ID
+
+
+@pytest.mark.asyncio
+async def test_get_or_create_upsert_on_read(db_session_with_users):
+    """初回 GET 時にデフォルト値でレコードが自動作成される"""
+    svc = NotificationPreferenceService(db_session_with_users)
+    pref = await svc.get_or_create(ADMIN_USER_ID)
+
+    assert pref.email_enabled is True
+    assert pref.slack_enabled is False
+    assert pref.slack_webhook_url is None
+    assert pref.events == DEFAULT_EVENTS
+
+
+@pytest.mark.asyncio
+async def test_get_or_create_idempotent(db_session_with_users):
+    """同じユーザーで複数回呼んでもレコードは1件"""
+    svc = NotificationPreferenceService(db_session_with_users)
+    pref1 = await svc.get_or_create(ADMIN_USER_ID)
+    pref2 = await svc.get_or_create(ADMIN_USER_ID)
+
+    # 同じ内容が返る
+    assert pref1.email_enabled == pref2.email_enabled
+    assert pref1.events == pref2.events
+
+
+@pytest.mark.asyncio
+async def test_update_preferences_partial(db_session_with_users):
+    """部分更新: email_enabled のみ変更"""
+    svc = NotificationPreferenceService(db_session_with_users)
+    await svc.get_or_create(ADMIN_USER_ID)
+
+    data = NotificationPreferenceUpdate(email_enabled=False)
+    updated = await svc.update_preferences(ADMIN_USER_ID, data)
+
+    assert updated.email_enabled is False
+    assert updated.slack_enabled is False  # 変更されていない
+    assert updated.events == DEFAULT_EVENTS  # 変更されていない
+
+
+@pytest.mark.asyncio
+async def test_update_preferences_events_full_replace(db_session_with_users):
+    """events は完全置換される"""
+    svc = NotificationPreferenceService(db_session_with_users)
+    await svc.get_or_create(ADMIN_USER_ID)
+
+    new_events = {
+        "daily_report_submitted": {"email": False, "slack": True},
+    }
+    data = NotificationPreferenceUpdate(events=new_events)
+    updated = await svc.update_preferences(ADMIN_USER_ID, data)
+
+    assert updated.events == new_events
+    assert "safety_incident_created" not in updated.events
+
+
+@pytest.mark.asyncio
+async def test_update_preferences_creates_if_missing(db_session_with_users):
+    """update_preferences でもレコードが無ければ自動生成"""
+    svc = NotificationPreferenceService(db_session_with_users)
+    data = NotificationPreferenceUpdate(slack_enabled=True)
+    updated = await svc.update_preferences(VIEWER_USER_ID, data)
+
+    assert updated.slack_enabled is True
+    # デフォルト値が適用されている
+    assert updated.email_enabled is True
+    assert updated.events == DEFAULT_EVENTS
+
+
+@pytest.mark.asyncio
+async def test_update_preferences_slack_webhook(db_session_with_users):
+    """Slack Webhook URL の設定"""
+    svc = NotificationPreferenceService(db_session_with_users)
+    webhook = "https://example.com/webhook/notification-test"
+    data = NotificationPreferenceUpdate(
+        slack_enabled=True,
+        slack_webhook_url=webhook,  # type: ignore[arg-type]
+    )
+    updated = await svc.update_preferences(ADMIN_USER_ID, data)
+
+    assert updated.slack_enabled is True
+    assert updated.slack_webhook_url == webhook
+
+
+@pytest.mark.asyncio
+async def test_users_have_isolated_preferences(db_session_with_users):
+    """ユーザーごとに設定が分離されている"""
+    svc = NotificationPreferenceService(db_session_with_users)
+
+    await svc.update_preferences(
+        ADMIN_USER_ID,
+        NotificationPreferenceUpdate(email_enabled=False),
+    )
+    await svc.update_preferences(
+        VIEWER_USER_ID,
+        NotificationPreferenceUpdate(slack_enabled=True),
+    )
+
+    admin_pref = await svc.get_or_create(ADMIN_USER_ID)
+    viewer_pref = await svc.get_or_create(VIEWER_USER_ID)
+
+    assert admin_pref.email_enabled is False
+    assert admin_pref.slack_enabled is False
+    assert viewer_pref.email_enabled is True
+    assert viewer_pref.slack_enabled is True

--- a/docs/03_設計（Design）/07_通知機能設計（Notification Feature）.md
+++ b/docs/03_設計（Design）/07_通知機能設計（Notification Feature）.md
@@ -1,0 +1,161 @@
+# 通知機能設計（Notification Feature）
+
+**作成日**: 2026-04-10
+**ステータス**: Phase 1 実装中
+**関連 Issue**: (TBD — 本ドキュメント作成後に起票)
+
+## 1. 背景と目的
+
+### 現状の課題
+ServiceHub Construction Platform は工事案件 / 日報 / 安全品質 / ITSM / 変更要求など複数の業務フローを提供しているが、重要イベント発生時にユーザーへプロアクティブに通知する仕組みが存在しない。現状ではユーザーがシステムにログインしない限り新規事象を検知できず、以下のような問題がある。
+
+- 日報が提出されても承認者が気づかず、承認フローが滞留
+- 安全インシデントが発生しても現場監督者の把握が遅れる
+- ITSM 変更要求の承認依頼が見逃される
+- 担当案件のステータス変更がタイムリーに伝わらない
+
+### 目的
+ユーザーにとって重要なイベントが発生した際に、メール・Slack 等の外部チャンネル経由でプッシュ通知を届ける仕組みを構築する。
+
+## 2. 段階的実装計画
+
+本機能は影響範囲が大きいため、2 段階で実装する。**本セッションでは Phase 1 のみを完走させる**。
+
+### Phase 1: 通知設定の管理（本 PR スコープ）
+
+ユーザーごとの通知購読設定を管理する基盤を構築する。**実送信はまだ行わない。**
+
+**目的**: 設定データモデルと CRUD API を確立し、将来の Phase 2 実装時の手戻りを最小化する。
+
+**成果物**:
+- `notification_preferences` テーブル
+- `GET /api/v1/users/me/notification-preferences` — 現在のユーザーの設定取得
+- `PATCH /api/v1/users/me/notification-preferences` — 設定更新
+- 認証必須・自ユーザーのみアクセス可
+- 3 層アーキテクチャ（Router → Service → Repository）に準拠
+- pytest による単体・統合テスト
+
+### Phase 2: 実送信基盤（将来セッション）
+
+**目的**: イベント発生時に実際に通知を配信する。
+
+**成果物**:
+- ドメインイベントフック（DailyReport 提出時 / Incident 作成時 / ChangeRequest 承認依頼時など）
+- Email 送信: SMTP (aiosmtplib) または SendGrid API
+- Slack 送信: Incoming Webhook (httpx POST)
+- 配信ログテーブル (`notification_deliveries`)
+- 配信失敗のリトライ方針（ジョブキュー or 同期リトライ）
+- テンプレート管理（Jinja2 or dict-based）
+- フロントエンド: 設定ページに通知トグル UI 追加
+
+## 3. Phase 1 データモデル
+
+### notification_preferences テーブル
+
+1 ユーザーにつき 1 レコード（user_id UNIQUE）。個別のイベント種別 × チャンネルの購読可否を JSON 形式で保持する。
+
+| カラム | 型 | 制約 | 説明 |
+|---|---|---|---|
+| `id` | UUID | PK | 主キー |
+| `user_id` | UUID | FK(users.id), UNIQUE | ユーザーID |
+| `email_enabled` | Boolean | NOT NULL, default=true | メール通知のマスタースイッチ |
+| `slack_enabled` | Boolean | NOT NULL, default=false | Slack 通知のマスタースイッチ |
+| `slack_webhook_url` | String(500) | NULL | Slack Incoming Webhook URL |
+| `events` | JSON | NOT NULL, default='{}' | イベント種別ごとの購読設定 |
+| `created_at` | DateTime(tz) | NOT NULL | 作成日時 |
+| `updated_at` | DateTime(tz) | NOT NULL | 更新日時 |
+
+### events JSON 構造
+
+```json
+{
+  "daily_report_submitted": { "email": true, "slack": false },
+  "safety_incident_created": { "email": true, "slack": true },
+  "change_request_pending_approval": { "email": true, "slack": false },
+  "incident_assigned": { "email": true, "slack": false },
+  "project_status_changed": { "email": false, "slack": false }
+}
+```
+
+### 初期サポートイベント種別
+
+| イベントキー | 発火タイミング | 対象ユーザー |
+|---|---|---|
+| `daily_report_submitted` | DailyReport.status=SUBMITTED | 承認権限者 (MANAGER, ADMIN) |
+| `safety_incident_created` | Incident 新規作成 | 担当案件の MANAGER |
+| `change_request_pending_approval` | ChangeRequest.status=PENDING_APPROVAL | 承認者 (ADMIN) |
+| `incident_assigned` | Incident.assigned_to 設定 | アサイン先ユーザー |
+| `project_status_changed` | Project.status 変更 | 案件関係者 |
+
+## 4. API 設計（Phase 1）
+
+### GET /api/v1/users/me/notification-preferences
+
+自ユーザーの通知設定を取得。レコードが存在しない場合はデフォルト値で自動作成して返す（upsert-on-read）。
+
+**Response 200**:
+```json
+{
+  "success": true,
+  "data": {
+    "email_enabled": true,
+    "slack_enabled": false,
+    "slack_webhook_url": null,
+    "events": {
+      "daily_report_submitted": { "email": true, "slack": false },
+      "safety_incident_created": { "email": true, "slack": true },
+      "change_request_pending_approval": { "email": true, "slack": false },
+      "incident_assigned": { "email": true, "slack": false },
+      "project_status_changed": { "email": false, "slack": false }
+    }
+  }
+}
+```
+
+### PATCH /api/v1/users/me/notification-preferences
+
+部分更新。送信されたフィールドのみ反映。events は完全置換（部分マージではない）で上書きする。
+
+**Request**:
+```json
+{
+  "email_enabled": true,
+  "slack_enabled": true,
+  "slack_webhook_url": "https://hooks.slack.com/services/...",
+  "events": { ... }
+}
+```
+
+**Response 200**: GET と同じ構造。
+
+## 5. セキュリティ / 認可
+
+- すべてのエンドポイントで `get_current_user` 依存が必須
+- 自ユーザーの設定のみアクセス可能（他ユーザーの設定を閲覧・変更する API は提供しない）
+- `slack_webhook_url` は機密情報として扱う（ログに出力しない、frontend で `type="password"` マスク推奨）
+- Phase 2 で実送信を実装する際、Webhook URL は暗号化保存を検討
+
+## 6. 非スコープ（本 PR では実装しない）
+
+- 実際の通知送信処理（email / Slack）
+- Email テンプレート
+- ドメインイベントフック
+- 配信ログ
+- リトライ機構
+- フロントエンド UI（設定ページへの統合は次 PR）
+- E2E テスト（UI 未実装のため）
+- プッシュ通知（WebPush / モバイル）
+
+## 7. テスト方針（Phase 1）
+
+| レイヤ | 対象 | 観点 |
+|---|---|---|
+| Repository | `get_by_user_id`, `create`, `update` | upsert 動作、UNIQUE 制約 |
+| Service | `get_or_create`, `update_preferences` | デフォルト値生成、更新の排他性 |
+| Router | `GET`, `PATCH` | 認証必須、自ユーザー限定、JSON バリデーション |
+
+## 8. 決定事項
+
+- **JSON カラム採用**: events 種別の追加削除頻度が読めないため、リレーショナル分解より JSON 保持が柔軟性が高い。検索条件は「特定ユーザーの設定取得」のみで、イベント種別での横断検索は不要。
+- **upsert-on-read**: GET 時に未設定なら自動生成することで、フロントエンドが常にデフォルト値を取得でき、「レコード未作成」という 404 状態を排除する。
+- **events 完全置換**: PATCH で events を送信した場合は完全置換とする。部分マージは複雑性が高く、フロントエンドが全量送信する前提で問題ない。

--- a/state.json
+++ b/state.json
@@ -1,15 +1,15 @@
 {
-  "phase": "Phase 2 - 機能強化（Day 7 進行中）",
+  "phase": "Phase 2 - 機能強化（Day 7 通知機能Phase1）",
   "loop": "Day7-Build",
-  "loop_count": 58,
+  "loop_count": 62,
   "status": "stable",
-  "last_updated": "2026-04-10T17:15:00+09:00",
+  "last_updated": "2026-04-10T16:20:00+09:00",
   "execution": {
-    "start_time": "2026-04-10T01:00:00+09:00",
+    "start_time": "2026-04-10T14:19:00+09:00",
     "max_duration_minutes": 300,
-    "elapsed_minutes": 0,
-    "remaining_minutes": 300,
-    "phase": "Monitor",
+    "elapsed_minutes": 120,
+    "remaining_minutes": 180,
+    "phase": "Build",
     "auto_stop_threshold": 5,
     "graceful_shutdown": false
   },
@@ -42,17 +42,15 @@
   },
   "priorities": {
     "high": [
-      "通知機能検討（メール/Slack）"
+      "通知機能 Phase 1 (preferences 管理)"
     ],
     "medium": [
-      "通知機能検討（メール/Slack）",
+      "通知機能 Phase 2 (実送信 email/slack)",
       "パフォーマンス計測基盤"
     ],
     "low": [
-      "通知機能検討（メール/Slack）",
       "ダークモード対応",
-      "i18n 基盤検討",
-      "パフォーマンス計測基盤"
+      "i18n 基盤検討"
     ]
   },
   "decision_context": {


### PR DESCRIPTION
Issue #91 の Phase 1 実装。ユーザーごとの通知購読設定を管理する基盤を構築する。**実際の通知送信は Phase 2 で対応予定。**

## 変更内容

### データモデル
- `notification_preferences` テーブル + Alembic migration (0008)
- `NotificationPreference` モデル (SQLAlchemy)
- UNIQUE(user_id) 制約で 1 ユーザー = 1 レコード
- `events` カラムはイベント種別 × チャンネルの購読可否を JSON で管理

### API
- `GET /api/v1/users/me/notification-preferences` — 自ユーザーの設定取得
- `PATCH /api/v1/users/me/notification-preferences` — 部分更新
- 認証必須・自ユーザーのみアクセス可
- **upsert-on-read**: GET 時にレコードが無ければデフォルト値で自動生成し、フロントエンドが 404 を考慮しなくて済む設計

### 3 層アーキテクチャ
- Repository: `app/repositories/notification_preference.py`
- Service: `app/services/notification_preference_service.py`
- Router: `app/api/v1/routers/notification_preferences.py`

### 設計ドキュメント
- `docs/03_設計（Design）/07_通知機能設計（Notification Feature）.md` 追加
- Phase 1 / Phase 2 のスコープを明示

## テスト結果

| 層 | テスト数 | 結果 |
|---|---|---|
| Unit (NotificationPreferenceService) | 7 | ✅ 全 pass |
| Integration (API) | 7 | ✅ 全 pass |
| **合計** | **14** | **✅ 全 pass** |

`notification_preference_service.py` coverage: **100%**

## 影響範囲

- **新規追加のみ** — 既存エンドポイント・モデルへの変更なし
- 既存テスト 185 件に影響なし（+14 → backend 合計 199 件）
- フロントエンドは **次 PR で対応**（本 PR ではバックエンドのみ）

## 非スコープ（Phase 2 で対応）

- 実際の通知送信処理（Email / Slack）
- ドメインイベントフック
- 配信ログテーブル
- フロントエンド UI 統合
- E2E テスト

## 互換性メモ

SQLite テスト DB で動作させるため、モデル側は汎用 `JSON` 型を使用。
本番 PostgreSQL は Alembic migration で `JSONB` を指定し、性能を確保。

## 受入れ条件

- [x] 設計ドキュメント作成
- [x] データモデル + migration
- [x] 3 層アーキテクチャ準拠
- [x] upsert-on-read 動作
- [x] 認証必須・自ユーザー限定の認可
- [x] ローカル ruff check / ruff format 通過
- [x] ローカル mypy (新規ファイル) エラー 0
- [x] ローカル pytest 14/14 pass
- [ ] CI 全 14 チェック green ← 本 PR 完了の最終条件

## 関連 Issue

Closes #91 (Phase 1 のみ。Phase 2 は別 Issue で継続)

🤖 Generated with [Claude Code](https://claude.com/claude-code)