### PR TITLE
feat(notifications): 通知機能 Phase 2a — Dispatcher + Email 送信基盤

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ graph TB
 | 📡       | システム            | ヘルスチェック / ステータス確認 | 2     | ✅ 完了     |
 | 📊       | Dashboard KPI API   | 集計 KPI 取得 / React Query hook | 1   | ✅ 完了     |
 | 🔔       | 通知設定            | 通知購読 preferences 管理 (Phase 1 / UI 統合済) | 2   | ✅ 完了     |
+| 📧       | 通知配信基盤        | Dispatcher + EmailSender + Jinja2 テンプレ (Phase 2a / PR#95) | 0   | 🟡 進行中 |
 
 ### 🧩 共通 UI コンポーネント（`src/components/ui/`）
 
@@ -102,10 +103,10 @@ graph TB
 
 | 指標 | 値 |
 | :--- | :--- |
-| 🧪 Backend テスト | **199 件**（pytest / coverage **96%**） |
+| 🧪 Backend テスト | **239 件**（pytest / coverage **96%** / 通知 Phase 2a +40 [初回 15 + Codex fix 25]） |
 | 🧪 Frontend テスト | **263 件**（vitest / 41 テストファイル / coverage **88%**） |
 | 🎭 E2E テスト | **165 件**（Playwright / 24 テストファイル） |
-| 📊 総テスト数 | **627 件**（Backend + Frontend + E2E） |
+| 📊 総テスト数 | **667 件**（Backend + Frontend + E2E） |
 | 🖥️ フロントエンドページ | **12 ページ**（全ページテスト済み・設定ページ追加） |
 | 🧩 共通 UI コンポーネント | **12 種**（Badge / Button / Card / ErrorBanner / ErrorBoundary / ErrorText / FormField / Modal / Pagination / Skeleton / StatCard / Table） |
 | 🎨 共通 UI 適用率 | **11/11 ページ**（全ページ統一完了） |
@@ -142,6 +143,7 @@ graph LR
 | 🖼️ PhotoService | 写真アップロード・バリデーション・プリサインドURL |
 | 📊 DashboardService | KPI 集約・統計ダッシュボード |
 | 🔔 NotificationPreferenceService | 通知購読設定 CRUD (upsert-on-read 方式) |
+| 📧 NotificationDispatcher | 通知配信オーケストレータ — 購読判定 → 事前書き込み → EmailSender 呼出 → status 更新 (Phase 2a) |
 
 > **全 10 Router が Router → Service → Repository の3層構造に統一（Service 12クラス / Repository 9クラス）。**
 

--- a/backend/alembic/versions/0009_notification_deliveries.py
+++ b/backend/alembic/versions/0009_notification_deliveries.py
@@ -1,0 +1,77 @@
+"""Notification deliveries table
+
+Revision ID: 0009
+Revises: 0008
+Create Date: 2026-04-11
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "0009"
+down_revision = "0008"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "notification_deliveries",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column(
+            "user_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("event_key", sa.String(100), nullable=False),
+        sa.Column("channel", sa.String(20), nullable=False),
+        sa.Column(
+            "status",
+            sa.String(20),
+            nullable=False,
+            server_default=sa.text("'PENDING'"),
+        ),
+        sa.Column("subject", sa.String(300), nullable=True),
+        sa.Column("body_preview", sa.Text, nullable=True),
+        sa.Column("error_detail", sa.Text, nullable=True),
+        sa.Column(
+            "attempts",
+            sa.Integer,
+            nullable=False,
+            server_default=sa.text("0"),
+        ),
+        sa.Column("sent_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+    )
+    op.create_index(
+        "ix_notification_deliveries_user_event_created",
+        "notification_deliveries",
+        ["user_id", "event_key", "created_at"],
+    )
+    op.create_index(
+        "ix_notification_deliveries_status_created",
+        "notification_deliveries",
+        ["status", "created_at"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_notification_deliveries_status_created", "notification_deliveries"
+    )
+    op.drop_index(
+        "ix_notification_deliveries_user_event_created", "notification_deliveries"
+    )
+    op.drop_table("notification_deliveries")

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -50,6 +50,19 @@ class Settings(BaseSettings):
     MINIO_SECRET_KEY: str = "minioadmin"
     MINIO_BUCKET: str = "servicehub"
 
+    # SMTP / Email 通知設定（Phase 2a）
+    # 開発環境は Mailhog 互換 SMTP (認証なし / TLS なし) を想定。
+    # 本番は環境変数で上書きする。
+    SMTP_HOST: str = "mailhog"
+    SMTP_PORT: int = 1025
+    SMTP_USERNAME: str | None = None
+    SMTP_PASSWORD: str | None = None
+    SMTP_USE_TLS: bool = False
+    SMTP_USE_STARTTLS: bool = False
+    SMTP_TIMEOUT_SECONDS: int = 10
+    SMTP_FROM_ADDRESS: str = "noreply@servicehub.local"
+    SMTP_FROM_NAME: str = "ServiceHub"
+
     model_config = SettingsConfigDict(env_file=".env", extra="ignore")
 
 

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -5,6 +5,7 @@ from app.models.cost import CostRecord, WorkHour
 from app.models.daily_report import DailyReport
 from app.models.itsm import ChangeRequest, Incident
 from app.models.knowledge import AiSearchLog, KnowledgeArticle
+from app.models.notification_delivery import NotificationDelivery
 from app.models.notification_preference import NotificationPreference
 from app.models.photo import Photo
 from app.models.project import Project
@@ -26,4 +27,5 @@ __all__ = [
     "KnowledgeArticle",
     "AiSearchLog",
     "NotificationPreference",
+    "NotificationDelivery",
 ]

--- a/backend/app/models/notification_delivery.py
+++ b/backend/app/models/notification_delivery.py
@@ -1,0 +1,62 @@
+"""通知配信ログモデル（SQLAlchemy）
+
+Phase 2a: NotificationDispatcher が通知を送信する際、送信前に PENDING 行を
+挿入し、送信完了後に SENT / FAILED へ更新する (事前書き込み方式)。
+この方式により送信途中クラッシュが RETRY 候補として残り、Phase 2d のリトライ
+機構が status スキャンで回収できる。
+"""
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, ForeignKey, Index, Integer, String, Text, Uuid, func
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db.base import Base
+
+
+class NotificationDelivery(Base):
+    __tablename__ = "notification_deliveries"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        Uuid(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        Uuid(as_uuid=True),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    event_key: Mapped[str] = mapped_column(String(100), nullable=False)
+    channel: Mapped[str] = mapped_column(String(20), nullable=False)
+    status: Mapped[str] = mapped_column(String(20), nullable=False, default="PENDING")
+    subject: Mapped[str | None] = mapped_column(String(300), nullable=True)
+    # Body preview is capped at 500 chars in application layer to limit PII exposure.
+    body_preview: Mapped[str | None] = mapped_column(Text, nullable=True)
+    error_detail: Mapped[str | None] = mapped_column(Text, nullable=True)
+    attempts: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    sent_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+
+    __table_args__ = (
+        Index(
+            "ix_notification_deliveries_user_event_created",
+            "user_id",
+            "event_key",
+            "created_at",
+        ),
+        Index(
+            "ix_notification_deliveries_status_created",
+            "status",
+            "created_at",
+        ),
+    )
+
+    def __repr__(self) -> str:
+        return (
+            f"<NotificationDelivery id={self.id} user_id={self.user_id} "
+            f"event={self.event_key} channel={self.channel} status={self.status}>"
+        )

--- a/backend/app/repositories/notification_delivery.py
+++ b/backend/app/repositories/notification_delivery.py
@@ -1,0 +1,62 @@
+"""通知配信ログリポジトリ（DB 操作レイヤー）
+
+Phase 2a の書き込みパターン:
+1. `create_pending` で PENDING 行を先に挿入 (事前書き込み方式)
+2. 送信成功時 `mark_sent` で status=SENT + sent_at を更新
+3. 送信失敗時 `mark_failed` で status=FAILED + error_detail を更新
+"""
+
+import uuid
+from datetime import datetime, timezone
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.notification_delivery import NotificationDelivery
+
+
+class NotificationDeliveryRepository:
+    def __init__(self, db: AsyncSession):
+        self.db = db
+
+    async def create_pending(
+        self,
+        user_id: uuid.UUID,
+        event_key: str,
+        channel: str,
+        subject: str | None,
+        body_preview: str | None,
+    ) -> NotificationDelivery:
+        delivery = NotificationDelivery(
+            user_id=user_id,
+            event_key=event_key,
+            channel=channel,
+            status="PENDING",
+            subject=subject,
+            body_preview=body_preview,
+            attempts=0,
+        )
+        self.db.add(delivery)
+        await self.db.flush()
+        await self.db.refresh(delivery)
+        return delivery
+
+    async def mark_sent(self, delivery: NotificationDelivery) -> NotificationDelivery:
+        delivery.status = "SENT"
+        delivery.sent_at = datetime.now(timezone.utc)
+        delivery.attempts += 1
+        delivery.error_detail = None
+        await self.db.flush()
+        await self.db.refresh(delivery)
+        return delivery
+
+    async def mark_failed(
+        self, delivery: NotificationDelivery, error_detail: str
+    ) -> NotificationDelivery:
+        delivery.status = "FAILED"
+        delivery.attempts += 1
+        # Truncate error detail to keep storage bounded; full stack traces
+        # tend to leak PII through user data embedded in frames.
+        delivery.error_detail = error_detail[:2000]
+        await self.db.flush()
+        await self.db.refresh(delivery)
+        return delivery

--- a/backend/app/repositories/notification_delivery.py
+++ b/backend/app/repositories/notification_delivery.py
@@ -4,14 +4,40 @@ Phase 2a の書き込みパターン:
 1. `create_pending` で PENDING 行を先に挿入 (事前書き込み方式)
 2. 送信成功時 `mark_sent` で status=SENT + sent_at を更新
 3. 送信失敗時 `mark_failed` で status=FAILED + error_detail を更新
+
+Idempotency guard (Codex review fix):
+    mark_sent / mark_failed は status=PENDING の行のみ遷移させる。
+    既に SENT/FAILED の行を再度遷移させようとしても no-op で返す。
+    これにより重複コール時の attempts 二重増加と terminal state の
+    上書きを防ぐ。
 """
 
+import re
 import uuid
 from datetime import datetime, timezone
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.notification_delivery import NotificationDelivery
+
+# RFC 5321 準拠は意図せず、実用的に「addr@host.tld」パターンだけ潰す。
+# SMTP エラー文字列のローカル/リモート・アドレス混入を抑える目的。
+_EMAIL_RE = re.compile(r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}")
+# SMTP レスポンスコードに続く server-supplied detail を潰す。
+# 例: "550 5.1.1 <user@ex.com>: Recipient rejected" → "550 5.1.1 [redacted]"
+_SMTP_RESP_RE = re.compile(r"(\b[245]\d{2}(?:\s+[45]\.\d+\.\d+)?)(.*)$", re.MULTILINE)
+
+
+def _sanitize_error_detail(raw: str) -> str:
+    """PII / server-identifying string を error_detail から除去する。
+
+    - メールアドレスを `[redacted-email]` に置換
+    - SMTP レスポンスコードは残すが server-supplied message 部は削る
+    - 先頭 1000 文字でさらに cap (元の 2000 は mark_failed 側で切る)
+    """
+    redacted = _EMAIL_RE.sub("[redacted-email]", raw)
+    redacted = _SMTP_RESP_RE.sub(r"\1 [redacted]", redacted)
+    return redacted[:1000]
 
 
 class NotificationDeliveryRepository:
@@ -41,6 +67,9 @@ class NotificationDeliveryRepository:
         return delivery
 
     async def mark_sent(self, delivery: NotificationDelivery) -> NotificationDelivery:
+        """PENDING → SENT 遷移。冪等性: PENDING 以外は no-op。"""
+        if delivery.status != "PENDING":
+            return delivery
         delivery.status = "SENT"
         delivery.sent_at = datetime.now(timezone.utc)
         delivery.attempts += 1
@@ -52,11 +81,15 @@ class NotificationDeliveryRepository:
     async def mark_failed(
         self, delivery: NotificationDelivery, error_detail: str
     ) -> NotificationDelivery:
+        """PENDING → FAILED 遷移。冪等性: PENDING 以外は no-op。
+
+        error_detail は PII サニタイズ後に保存する (§9.8 準拠)。
+        """
+        if delivery.status != "PENDING":
+            return delivery
         delivery.status = "FAILED"
         delivery.attempts += 1
-        # Truncate error detail to keep storage bounded; full stack traces
-        # tend to leak PII through user data embedded in frames.
-        delivery.error_detail = error_detail[:2000]
+        delivery.error_detail = _sanitize_error_detail(error_detail)
         await self.db.flush()
         await self.db.refresh(delivery)
         return delivery

--- a/backend/app/services/notification_dispatcher.py
+++ b/backend/app/services/notification_dispatcher.py
@@ -1,0 +1,140 @@
+"""通知配信オーケストレータ (Phase 2a)
+
+設計書 §9.2 のアーキテクチャを実装する:
+
+    dispatch(event_key, user_ids, context)
+      ├─ 購読ユーザー解決 (notification_preferences 参照)
+      ├─ 事前書き込み (delivery 行を PENDING で作成)
+      ├─ EmailSender 呼び出し
+      └─ mark_sent / mark_failed で status 更新
+
+Phase 2a スコープ:
+- Email チャンネルのみ (Slack は Phase 2b)
+- ドメインイベントフック接続なし (Phase 2c)
+- リトライなし (Phase 2d)
+"""
+
+import uuid
+from datetime import datetime, timezone
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import Settings, get_settings
+from app.models.notification_delivery import NotificationDelivery
+from app.models.user import User
+from app.repositories.notification_delivery import NotificationDeliveryRepository
+from app.repositories.notification_preference import NotificationPreferenceRepository
+from app.services.notification_senders import EmailSender
+from app.services.notification_templates import TemplateRenderer
+
+
+class NotificationDispatcher:
+    def __init__(
+        self,
+        db: AsyncSession,
+        *,
+        email_sender: EmailSender | None = None,
+        template_renderer: TemplateRenderer | None = None,
+        settings: Settings | None = None,
+    ) -> None:
+        self.db = db
+        self.delivery_repo = NotificationDeliveryRepository(db)
+        self.pref_repo = NotificationPreferenceRepository(db)
+        self.settings = settings or get_settings()
+        self.email_sender = email_sender or EmailSender(self.settings)
+        self.renderer = template_renderer or TemplateRenderer()
+
+    async def dispatch(
+        self,
+        *,
+        event_key: str,
+        user_ids: list[uuid.UUID],
+        context: dict[str, Any],
+    ) -> list[NotificationDelivery]:
+        """指定ユーザーのうち購読済みの者へ Email を送信する。
+
+        購読判定:
+            prefs.email_enabled AND prefs.events[event_key]["email"] == True
+        """
+        if not user_ids:
+            return []
+
+        users = await self._load_active_users(user_ids)
+        deliveries: list[NotificationDelivery] = []
+
+        for user in users:
+            if not await self._is_subscribed(user.id, event_key, "email"):
+                continue
+            delivery = await self._dispatch_email(
+                event_key=event_key, user=user, context=context
+            )
+            deliveries.append(delivery)
+
+        return deliveries
+
+    async def send_ping(self, *, user: User) -> NotificationDelivery:
+        """疎通テスト送信 (Phase 2b エンドポイントから呼ばれる想定)。
+
+        購読設定を無視して強制送信する。ユーザーが自分の設定を検証する
+        ための機能なので、「設定 OFF → 届かない」動作では意図が通らない。
+        """
+        context = {
+            "user_name": user.full_name,
+            "sent_at": datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC"),
+            "app_url": "https://servicehub.local",
+        }
+        return await self._dispatch_email(event_key="ping", user=user, context=context)
+
+    async def _dispatch_email(
+        self,
+        *,
+        event_key: str,
+        user: User,
+        context: dict[str, Any],
+    ) -> NotificationDelivery:
+        rendered = self.renderer.render_email(event_key, context)
+        delivery = await self.delivery_repo.create_pending(
+            user_id=user.id,
+            event_key=event_key,
+            channel="EMAIL",
+            subject=rendered.subject,
+            body_preview=rendered.body_text[:500],
+        )
+        result = await self.email_sender.send(
+            to=user.email,
+            subject=rendered.subject,
+            body_text=rendered.body_text,
+            body_html=rendered.body_html,
+        )
+        if result.ok:
+            return await self.delivery_repo.mark_sent(delivery)
+        return await self.delivery_repo.mark_failed(
+            delivery, result.error or "unknown error"
+        )
+
+    async def _is_subscribed(
+        self, user_id: uuid.UUID, event_key: str, channel: str
+    ) -> bool:
+        pref = await self.pref_repo.get_by_user_id(user_id)
+        if pref is None:
+            return False
+        if channel == "email" and not pref.email_enabled:
+            return False
+        if channel == "slack" and not pref.slack_enabled:
+            return False
+        event_prefs = pref.events.get(event_key)
+        if not isinstance(event_prefs, dict):
+            return False
+        return bool(event_prefs.get(channel, False))
+
+    async def _load_active_users(self, user_ids: list[uuid.UUID]) -> list[User]:
+        result = await self.db.execute(
+            select(User).where(
+                User.id.in_(user_ids),
+                User.is_active.is_(True),
+                User.deleted_at.is_(None),
+            )
+        )
+        return list(result.scalars().all())

--- a/backend/app/services/notification_dispatcher.py
+++ b/backend/app/services/notification_dispatcher.py
@@ -4,14 +4,32 @@
 
     dispatch(event_key, user_ids, context)
       ├─ 購読ユーザー解決 (notification_preferences 参照)
-      ├─ 事前書き込み (delivery 行を PENDING で作成)
-      ├─ EmailSender 呼び出し
-      └─ mark_sent / mark_failed で status 更新
+      ├─ 事前書き込み (PENDING) → commit
+      ├─ EmailSender 呼び出し (外部 I/O)
+      └─ mark_sent / mark_failed で status 更新 → commit
+
+=== Transaction boundary — 例外的責務に注意 ===
+通常 Service/Repository は commit を行わず、呼び出し側 (`get_db()`) が
+トランザクション境界を持つ慣用 (Phase 1 の NotificationPreferenceService 等)。
+しかし通知配信は「外部 I/O の前後で durable な記録を残す」必要があるため、
+NotificationDispatcher は自己トランザクション境界を持つ:
+
+    1. PENDING 行を書いて commit
+       (これで「送信を試みた」痕跡が DB に残る)
+    2. SMTP 送信 (外部 I/O — ここでクラッシュしても PENDING 行は残る)
+    3. 結果に応じて SENT/FAILED へ update → commit
+
+この規約からの逸脱は Codex review で指摘された durable tracking 要件
+(§9.1 / §9.4) を満たすための意図的な設計。呼び出し側は「自分の transaction
+が dispatch 内部で一度 commit される」ことを把握して呼び出す必要がある。
+Phase 2b 以降で BackgroundTasks 統合を入れ、独立 session で実行するように
+改修することで、この注意書きは不要になる予定。
 
 Phase 2a スコープ:
 - Email チャンネルのみ (Slack は Phase 2b)
 - ドメインイベントフック接続なし (Phase 2c)
-- リトライなし (Phase 2d)
+- リトライ機構なし (Phase 2d で failure_kind=transient を回収予定)
+- 同期実行 (BackgroundTasks 統合は Phase 2b)
 """
 
 import uuid
@@ -94,6 +112,14 @@ class NotificationDispatcher:
         user: User,
         context: dict[str, Any],
     ) -> NotificationDelivery:
+        """Email 1 通の送信。自己トランザクション境界を持つ (class docstring 参照)。
+
+        順序:
+            1. render
+            2. PENDING 行作成 + commit (durable tracking)
+            3. SMTP 送信 (外部 I/O)
+            4. 結果に応じて SENT/FAILED へ update + commit
+        """
         rendered = self.renderer.render_email(event_key, context)
         delivery = await self.delivery_repo.create_pending(
             user_id=user.id,
@@ -102,17 +128,26 @@ class NotificationDispatcher:
             subject=rendered.subject,
             body_preview=rendered.body_text[:500],
         )
+        # Commit #1: PENDING 行を durable に残す。ここでクラッシュしても
+        # 「送信を試みた」記録が残るため Phase 2d で回収可能。
+        await self.db.commit()
+
         result = await self.email_sender.send(
             to=user.email,
             subject=rendered.subject,
             body_text=rendered.body_text,
             body_html=rendered.body_html,
         )
+
         if result.ok:
-            return await self.delivery_repo.mark_sent(delivery)
-        return await self.delivery_repo.mark_failed(
-            delivery, result.error or "unknown error"
-        )
+            await self.delivery_repo.mark_sent(delivery)
+        else:
+            await self.delivery_repo.mark_failed(
+                delivery, result.error or "unknown error"
+            )
+        # Commit #2: 終了状態 (SENT/FAILED) を durable に残す。
+        await self.db.commit()
+        return delivery
 
     async def _is_subscribed(
         self, user_id: uuid.UUID, event_key: str, channel: str

--- a/backend/app/services/notification_senders/__init__.py
+++ b/backend/app/services/notification_senders/__init__.py
@@ -1,0 +1,5 @@
+"""通知送信チャンネル実装パッケージ (Phase 2a: Email, Phase 2b: Slack)"""
+
+from app.services.notification_senders.email_sender import EmailSender, SendResult
+
+__all__ = ["EmailSender", "SendResult"]

--- a/backend/app/services/notification_senders/email_sender.py
+++ b/backend/app/services/notification_senders/email_sender.py
@@ -5,8 +5,9 @@
   Dispatcher が事前書き込みした delivery 行を mark_sent / mark_failed へ
   一貫して遷移させ、Phase 2d のリトライ機構も同じ戻り値契約を再利用する。
 - 失敗は transient / permanent に分類する (Codex review fix)。
-  * transient: 接続失敗、タイムアウト、DNS 解決失敗 → リトライ候補
-  * permanent: 認証失敗、無効アドレス、4xx/5xx 応答 → リトライ不可
+  * transient: 接続失敗、タイムアウト、DNS 解決失敗、SMTP 4xx 応答 → リトライ候補
+  * permanent: 認証失敗、無効アドレス、SMTP 5xx 応答 → リトライ不可
+  * 未知例外は安全側で permanent (optimistic retry を防ぐ)
 - aiosmtplib はコンストラクタで `smtp_send` callable を差し替えてテスト可能。
 """
 

--- a/backend/app/services/notification_senders/email_sender.py
+++ b/backend/app/services/notification_senders/email_sender.py
@@ -1,0 +1,102 @@
+"""Email 送信チャンネル実装（aiosmtplib ラッパ）
+
+設計判断:
+- 失敗を例外で伝播せず `SendResult(ok, error)` で返す。Dispatcher が
+  事前書き込みした delivery 行を mark_sent / mark_failed へ一貫して遷移させ、
+  Phase 2d のリトライ機構でも同じ戻り値契約を再利用するため。
+- aiosmtplib はテスト時に `smtp_cls` 引数経由で差し替え可能。
+"""
+
+from dataclasses import dataclass
+from email.message import EmailMessage
+from typing import Protocol
+
+import aiosmtplib
+
+from app.core.config import Settings
+
+
+@dataclass(frozen=True)
+class SendResult:
+    """送信結果。例外を投げない契約のための戻り値オブジェクト。"""
+
+    ok: bool
+    error: str | None = None
+
+
+class _SmtpClient(Protocol):
+    """aiosmtplib.send と互換のシグネチャ (テスト差し替え用)。"""
+
+    async def __call__(
+        self,
+        message: EmailMessage,
+        *,
+        hostname: str,
+        port: int,
+        username: str | None,
+        password: str | None,
+        use_tls: bool,
+        start_tls: bool,
+        timeout: int,
+    ) -> object: ...
+
+
+class EmailSender:
+    """aiosmtplib を用いた Email 送信チャンネル。"""
+
+    def __init__(
+        self,
+        settings: Settings,
+        smtp_send: _SmtpClient | None = None,
+    ) -> None:
+        self.settings = settings
+        # Dependency injection point: unit tests pass a fake coroutine here
+        # instead of opening a real SMTP connection.
+        self._smtp_send = smtp_send or aiosmtplib.send  # type: ignore[assignment]
+
+    async def send(
+        self,
+        *,
+        to: str,
+        subject: str,
+        body_text: str,
+        body_html: str | None = None,
+    ) -> SendResult:
+        message = self._build_message(
+            to=to, subject=subject, body_text=body_text, body_html=body_html
+        )
+        try:
+            await self._smtp_send(
+                message,
+                hostname=self.settings.SMTP_HOST,
+                port=self.settings.SMTP_PORT,
+                username=self.settings.SMTP_USERNAME,
+                password=self.settings.SMTP_PASSWORD,
+                use_tls=self.settings.SMTP_USE_TLS,
+                start_tls=self.settings.SMTP_USE_STARTTLS,
+                timeout=self.settings.SMTP_TIMEOUT_SECONDS,
+            )
+        except Exception as exc:  # noqa: BLE001
+            # Intentionally broad: SMTP/network failures should become
+            # SendResult(ok=False) rather than propagating to the caller.
+            return SendResult(ok=False, error=f"{type(exc).__name__}: {exc}")
+        return SendResult(ok=True)
+
+    def _build_message(
+        self,
+        *,
+        to: str,
+        subject: str,
+        body_text: str,
+        body_html: str | None,
+    ) -> EmailMessage:
+        msg = EmailMessage()
+        msg["From"] = (
+            f"{self.settings.SMTP_FROM_NAME} <{self.settings.SMTP_FROM_ADDRESS}>"
+        )
+        msg["To"] = to
+        msg["Subject"] = subject
+        msg.set_content(body_text)
+        if body_html:
+            msg.add_alternative(body_html, subtype="html")
+        return msg

--- a/backend/app/services/notification_senders/email_sender.py
+++ b/backend/app/services/notification_senders/email_sender.py
@@ -1,27 +1,93 @@
 """Email 送信チャンネル実装（aiosmtplib ラッパ）
 
 設計判断:
-- 失敗を例外で伝播せず `SendResult(ok, error)` で返す。Dispatcher が
-  事前書き込みした delivery 行を mark_sent / mark_failed へ一貫して遷移させ、
-  Phase 2d のリトライ機構でも同じ戻り値契約を再利用するため。
-- aiosmtplib はテスト時に `smtp_cls` 引数経由で差し替え可能。
+- 失敗を例外で伝播せず `SendResult(ok, error, failure_kind)` で返す。
+  Dispatcher が事前書き込みした delivery 行を mark_sent / mark_failed へ
+  一貫して遷移させ、Phase 2d のリトライ機構も同じ戻り値契約を再利用する。
+- 失敗は transient / permanent に分類する (Codex review fix)。
+  * transient: 接続失敗、タイムアウト、DNS 解決失敗 → リトライ候補
+  * permanent: 認証失敗、無効アドレス、4xx/5xx 応答 → リトライ不可
+- aiosmtplib はコンストラクタで `smtp_send` callable を差し替えてテスト可能。
 """
 
 from dataclasses import dataclass
 from email.message import EmailMessage
-from typing import Protocol
+from typing import Literal, Protocol
 
 import aiosmtplib
+from aiosmtplib.errors import (
+    SMTPAuthenticationError,
+    SMTPConnectError,
+    SMTPConnectResponseError,
+    SMTPConnectTimeoutError,
+    SMTPDataError,
+    SMTPException,
+    SMTPNotSupported,
+    SMTPRecipientsRefused,
+    SMTPResponseException,
+    SMTPSenderRefused,
+    SMTPServerDisconnected,
+    SMTPTimeoutError,
+)
 
 from app.core.config import Settings
+
+FailureKind = Literal["transient", "permanent"]
 
 
 @dataclass(frozen=True)
 class SendResult:
-    """送信結果。例外を投げない契約のための戻り値オブジェクト。"""
+    """送信結果。例外を投げない契約のための戻り値オブジェクト。
+
+    failure_kind はリトライ判定に使う:
+    - transient: Phase 2d のリトライワーカーが後で再試行すべき
+    - permanent: リトライしても直らない (宛先無効・認証失敗など)
+    """
 
     ok: bool
     error: str | None = None
+    failure_kind: FailureKind | None = None
+
+
+# 接続・ネットワーク層の一時的失敗 (Phase 2d リトライ対象)
+_TRANSIENT_EXCEPTIONS: tuple[type[BaseException], ...] = (
+    SMTPConnectError,
+    SMTPConnectTimeoutError,
+    SMTPConnectResponseError,
+    SMTPServerDisconnected,
+    SMTPTimeoutError,
+    ConnectionError,
+    TimeoutError,
+    OSError,  # DNS failure, socket errors
+)
+
+# プロトコル層の恒久的失敗 (認証・宛先・コマンド拒否)
+_PERMANENT_EXCEPTIONS: tuple[type[BaseException], ...] = (
+    SMTPAuthenticationError,
+    SMTPRecipientsRefused,
+    SMTPSenderRefused,
+    SMTPDataError,
+    SMTPNotSupported,
+)
+
+
+def _classify(exc: BaseException) -> FailureKind:
+    """例外を transient / permanent に分類する。
+
+    未知の SMTP 例外は安全側に倒して permanent とする
+    (リトライしない方がユーザー/サーバー両方に優しい)。
+    """
+    if isinstance(exc, _TRANSIENT_EXCEPTIONS):
+        return "transient"
+    if isinstance(exc, _PERMANENT_EXCEPTIONS):
+        return "permanent"
+    if isinstance(exc, SMTPResponseException):
+        # 4xx は transient (サーバー一時エラー), 5xx は permanent
+        code = getattr(exc, "code", 0) or 0
+        return "transient" if 400 <= code < 500 else "permanent"
+    if isinstance(exc, SMTPException):
+        return "permanent"
+    return "permanent"
 
 
 class _SmtpClient(Protocol):
@@ -36,8 +102,8 @@ class _SmtpClient(Protocol):
         username: str | None,
         password: str | None,
         use_tls: bool,
-        start_tls: bool,
-        timeout: int,
+        start_tls: bool | None,
+        timeout: int | float,
     ) -> object: ...
 
 
@@ -77,9 +143,15 @@ class EmailSender:
                 timeout=self.settings.SMTP_TIMEOUT_SECONDS,
             )
         except Exception as exc:  # noqa: BLE001
-            # Intentionally broad: SMTP/network failures should become
-            # SendResult(ok=False) rather than propagating to the caller.
-            return SendResult(ok=False, error=f"{type(exc).__name__}: {exc}")
+            # Intentionally broad: SMTP/network failures become SendResult
+            # instead of propagating. Classification distinguishes retriable
+            # from permanent failures so Phase 2d retry worker has enough
+            # information to decide.
+            return SendResult(
+                ok=False,
+                error=f"{type(exc).__name__}: {exc}",
+                failure_kind=_classify(exc),
+            )
         return SendResult(ok=True)
 
     def _build_message(

--- a/backend/app/services/notification_templates/__init__.py
+++ b/backend/app/services/notification_templates/__init__.py
@@ -1,0 +1,16 @@
+"""通知テンプレート (Jinja2)
+
+Phase 2a では疎通テスト用の最小セットのみ配置する。Phase 2c でドメイン
+イベント別テンプレ (daily_report_submitted, safety_incident_created, ...)
+を追加していく。
+
+テンプレートの探索は `TemplateRenderer` 経由で行う。呼び出し側は
+`render(event_key, channel, context)` だけ知っていれば良い。
+"""
+
+from app.services.notification_templates.renderer import (
+    TemplateNotFoundError,
+    TemplateRenderer,
+)
+
+__all__ = ["TemplateRenderer", "TemplateNotFoundError"]

--- a/backend/app/services/notification_templates/email/ping.html.j2
+++ b/backend/app/services/notification_templates/email/ping.html.j2
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <body style="font-family: sans-serif; max-width: 600px; margin: 0 auto; padding: 16px;">
+    <h2 style="color: #1f2937;">🔔 通知疎通テスト</h2>
+    <p>{{ user_name }} 様</p>
+    <p>
+      ServiceHub Construction Platform の通知機能から疎通テストが送信されました。<br>
+      このメールが届いている場合、Email 通知チャンネルは正常に動作しています。
+    </p>
+    <p style="color: #6b7280; font-size: 14px;">
+      イベント種別ごとの購読設定は <strong>設定 &gt; 通知設定</strong> から変更できます。
+    </p>
+    <hr style="border: none; border-top: 1px solid #e5e7eb; margin: 24px 0;">
+    <p style="color: #9ca3af; font-size: 12px;">
+      送信日時: {{ sent_at }}<br>
+      ServiceHub Construction Platform<br>
+      <a href="{{ app_url }}" style="color: #2563eb;">{{ app_url }}</a>
+    </p>
+  </body>
+</html>

--- a/backend/app/services/notification_templates/email/ping.subject.j2
+++ b/backend/app/services/notification_templates/email/ping.subject.j2
@@ -1,0 +1,1 @@
+[ServiceHub] 通知疎通テスト ({{ user_name }} 様)

--- a/backend/app/services/notification_templates/email/ping.txt.j2
+++ b/backend/app/services/notification_templates/email/ping.txt.j2
@@ -1,0 +1,12 @@
+{{ user_name }} 様
+
+ServiceHub Construction Platform の通知機能から疎通テストが送信されました。
+
+このメールが届いている場合、Email 通知チャンネルは正常に動作しています。
+イベント種別ごとの購読設定は「設定 > 通知設定」から変更できます。
+
+送信日時: {{ sent_at }}
+
+--
+ServiceHub Construction Platform
+{{ app_url }}

--- a/backend/app/services/notification_templates/renderer.py
+++ b/backend/app/services/notification_templates/renderer.py
@@ -1,0 +1,79 @@
+"""Jinja2 テンプレートレンダラ
+
+ディレクトリ構造:
+
+    notification_templates/
+    ├── email/
+    │   ├── <event_key>.subject.j2   # メール件名 (1行)
+    │   ├── <event_key>.txt.j2       # プレーンテキスト本文
+    │   └── <event_key>.html.j2      # HTML 本文 (オプション)
+    └── slack/                       # Phase 2b で追加
+        └── <event_key>.txt.j2
+
+event_key はドメインイベント識別子 (`daily_report_submitted` 等)。
+Phase 2a では `ping` イベント (疎通テスト用) のみ同梱する。
+"""
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from jinja2 import (
+    Environment,
+    FileSystemLoader,
+    StrictUndefined,
+    TemplateNotFound,
+    select_autoescape,
+)
+
+_TEMPLATE_DIR = Path(__file__).parent
+
+
+class TemplateNotFoundError(LookupError):
+    """指定された event_key / channel のテンプレートが存在しない。"""
+
+
+@dataclass(frozen=True)
+class RenderedEmail:
+    subject: str
+    body_text: str
+    body_html: str | None
+
+
+class TemplateRenderer:
+    def __init__(self, template_dir: Path | None = None) -> None:
+        self._env = Environment(
+            loader=FileSystemLoader(template_dir or _TEMPLATE_DIR),
+            autoescape=select_autoescape(["html", "htm"]),
+            undefined=StrictUndefined,
+            trim_blocks=True,
+            lstrip_blocks=True,
+        )
+
+    def render_email(self, event_key: str, context: dict[str, Any]) -> RenderedEmail:
+        subject_raw = self._render_required(f"email/{event_key}.subject.j2", context)
+        body_text = self._render_required(f"email/{event_key}.txt.j2", context)
+        body_html = self._render_optional(f"email/{event_key}.html.j2", context)
+        return RenderedEmail(
+            subject=subject_raw.strip(),
+            body_text=body_text,
+            body_html=body_html,
+        )
+
+    def _render_required(self, template_name: str, context: dict[str, Any]) -> str:
+        try:
+            template = self._env.get_template(template_name)
+        except TemplateNotFound as exc:
+            raise TemplateNotFoundError(
+                f"required template not found: {template_name}"
+            ) from exc
+        return template.render(**context)
+
+    def _render_optional(
+        self, template_name: str, context: dict[str, Any]
+    ) -> str | None:
+        try:
+            template = self._env.get_template(template_name)
+        except TemplateNotFound:
+            return None
+        return template.render(**context)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -31,6 +31,10 @@ pydantic==2.9.2
 pydantic-settings==2.5.2
 email-validator==2.2.0
 
+# ── Notifications (Phase 2a) ─────────────────────────
+aiosmtplib==3.0.2
+jinja2==3.1.4
+
 # ── AI / ML ──────────────────────────────────────────
 openai==1.47.0
 tiktoken==0.7.0

--- a/backend/tests/unit/test_email_sender.py
+++ b/backend/tests/unit/test_email_sender.py
@@ -1,0 +1,118 @@
+"""EmailSender のユニットテスト
+
+aiosmtplib.send の依存注入ポイントを使い、実 SMTP サーバーに接続せずに
+「正常送信」「例外伝播の抑制」「メッセージ組み立て」を検証する。
+"""
+
+from email.message import EmailMessage
+
+import pytest
+
+from app.core.config import get_settings
+from app.services.notification_senders.email_sender import EmailSender, SendResult
+
+
+class _FakeSmtpSend:
+    """aiosmtplib.send 互換のスパイ。呼び出し引数を記録する。"""
+
+    def __init__(self, raise_exc: Exception | None = None) -> None:
+        self.raise_exc = raise_exc
+        self.calls: list[dict] = []
+
+    async def __call__(self, message: EmailMessage, **kwargs) -> None:
+        self.calls.append({"message": message, **kwargs})
+        if self.raise_exc is not None:
+            raise self.raise_exc
+
+
+@pytest.mark.asyncio
+async def test_send_success_returns_ok_result():
+    spy = _FakeSmtpSend()
+    sender = EmailSender(settings=get_settings(), smtp_send=spy)
+
+    result = await sender.send(
+        to="user@example.com",
+        subject="Hello",
+        body_text="This is the body.",
+    )
+
+    assert result == SendResult(ok=True)
+    assert len(spy.calls) == 1
+    call = spy.calls[0]
+    assert call["hostname"] == get_settings().SMTP_HOST
+    assert call["port"] == get_settings().SMTP_PORT
+
+
+@pytest.mark.asyncio
+async def test_send_failure_is_captured_not_raised():
+    """SMTP 例外は SendResult(ok=False) に変換され、呼び出し側には伝播しない。
+
+    fire-and-forget 契約の心臓部: Dispatcher が例外で死なないことを保証する。
+    """
+    spy = _FakeSmtpSend(raise_exc=ConnectionRefusedError("no smtp server"))
+    sender = EmailSender(settings=get_settings(), smtp_send=spy)
+
+    result = await sender.send(
+        to="user@example.com",
+        subject="Hello",
+        body_text="body",
+    )
+
+    assert result.ok is False
+    assert result.error is not None
+    assert "ConnectionRefusedError" in result.error
+    assert "no smtp server" in result.error
+
+
+@pytest.mark.asyncio
+async def test_send_builds_message_with_headers_and_body():
+    spy = _FakeSmtpSend()
+    settings = get_settings()
+    sender = EmailSender(settings=settings, smtp_send=spy)
+
+    await sender.send(
+        to="recipient@example.com",
+        subject="件名テスト",
+        body_text="プレーンテキスト本文",
+        body_html="<p>HTML 本文</p>",
+    )
+
+    msg = spy.calls[0]["message"]
+    assert msg["To"] == "recipient@example.com"
+    assert msg["Subject"] == "件名テスト"
+    # From ヘッダに表示名と address が組み立てられていること
+    assert settings.SMTP_FROM_ADDRESS in msg["From"]
+    assert settings.SMTP_FROM_NAME in msg["From"]
+    # multipart/alternative になっていること (text + html)
+    assert msg.is_multipart()
+
+
+@pytest.mark.asyncio
+async def test_send_text_only_is_not_multipart():
+    spy = _FakeSmtpSend()
+    sender = EmailSender(settings=get_settings(), smtp_send=spy)
+
+    await sender.send(
+        to="recipient@example.com",
+        subject="No HTML",
+        body_text="just text",
+    )
+
+    msg = spy.calls[0]["message"]
+    assert not msg.is_multipart()
+
+
+@pytest.mark.asyncio
+async def test_send_timeout_error_captured():
+    """TimeoutError のような非 SMTP 例外も SendResult(ok=False) で吸収される。"""
+    spy = _FakeSmtpSend(raise_exc=TimeoutError("smtp hang"))
+    sender = EmailSender(settings=get_settings(), smtp_send=spy)
+
+    result = await sender.send(
+        to="user@example.com",
+        subject="s",
+        body_text="b",
+    )
+
+    assert result.ok is False
+    assert "TimeoutError" in (result.error or "")

--- a/backend/tests/unit/test_email_sender_classification.py
+++ b/backend/tests/unit/test_email_sender_classification.py
@@ -1,0 +1,107 @@
+"""EmailSender の失敗分類 (transient / permanent) テスト (Codex review fix)"""
+
+import pytest
+from aiosmtplib.errors import (
+    SMTPAuthenticationError,
+    SMTPConnectError,
+    SMTPConnectTimeoutError,
+    SMTPRecipientsRefused,
+    SMTPResponseException,
+    SMTPServerDisconnected,
+    SMTPTimeoutError,
+)
+
+from app.core.config import get_settings
+from app.services.notification_senders.email_sender import (
+    EmailSender,
+    _classify,
+)
+
+
+class _RaisingSend:
+    def __init__(self, exc: BaseException) -> None:
+        self.exc = exc
+
+    async def __call__(self, *args, **kwargs) -> None:
+        raise self.exc
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        SMTPConnectError("cant connect"),
+        SMTPConnectTimeoutError("timed out"),
+        SMTPServerDisconnected("server dropped"),
+        SMTPTimeoutError("read timeout"),
+        ConnectionError("boom"),
+        TimeoutError("slow"),
+        OSError(99, "network unreachable"),  # socket.gaierror parent
+    ],
+)
+def test_classify_transient_exceptions(exc):
+    assert _classify(exc) == "transient"
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        SMTPAuthenticationError(535, "auth failed"),
+        SMTPRecipientsRefused([]),
+    ],
+)
+def test_classify_permanent_exceptions(exc):
+    assert _classify(exc) == "permanent"
+
+
+def test_classify_smtp_response_4xx_is_transient():
+    exc = SMTPResponseException(451, "try again later")
+    assert _classify(exc) == "transient"
+
+
+def test_classify_smtp_response_5xx_is_permanent():
+    exc = SMTPResponseException(550, "mailbox unavailable")
+    assert _classify(exc) == "permanent"
+
+
+def test_classify_unknown_exception_defaults_to_permanent():
+    """未知例外は安全側 (リトライしない) に倒す。"""
+
+    class _UnknownError(Exception):
+        pass
+
+    assert _classify(_UnknownError("mystery")) == "permanent"
+
+
+@pytest.mark.asyncio
+async def test_send_populates_failure_kind_transient():
+    sender = EmailSender(
+        settings=get_settings(),
+        smtp_send=_RaisingSend(SMTPConnectTimeoutError("cant reach")),
+    )
+    result = await sender.send(to="u@example.com", subject="s", body_text="b")
+    assert result.ok is False
+    assert result.failure_kind == "transient"
+
+
+@pytest.mark.asyncio
+async def test_send_populates_failure_kind_permanent():
+    sender = EmailSender(
+        settings=get_settings(),
+        smtp_send=_RaisingSend(SMTPAuthenticationError(535, "auth")),
+    )
+    result = await sender.send(to="u@example.com", subject="s", body_text="b")
+    assert result.ok is False
+    assert result.failure_kind == "permanent"
+
+
+@pytest.mark.asyncio
+async def test_send_success_has_no_failure_kind():
+    class _OkSend:
+        async def __call__(self, *args, **kwargs) -> None:
+            return None
+
+    sender = EmailSender(settings=get_settings(), smtp_send=_OkSend())
+    result = await sender.send(to="u@example.com", subject="s", body_text="b")
+    assert result.ok is True
+    assert result.failure_kind is None
+    assert result.error is None

--- a/backend/tests/unit/test_notification_delivery_repo.py
+++ b/backend/tests/unit/test_notification_delivery_repo.py
@@ -1,0 +1,151 @@
+"""NotificationDeliveryRepository の冪等性 + サニタイズ (Codex review fix)"""
+
+import uuid
+
+import pytest
+from sqlalchemy import select
+
+from app.models.notification_delivery import NotificationDelivery
+from app.repositories.notification_delivery import (
+    NotificationDeliveryRepository,
+    _sanitize_error_detail,
+)
+from tests.conftest import ADMIN_USER_ID
+
+
+async def _make_pending(
+    db_session_with_users, user_id=ADMIN_USER_ID
+) -> NotificationDelivery:
+    repo = NotificationDeliveryRepository(db_session_with_users)
+    return await repo.create_pending(
+        user_id=user_id,
+        event_key="x",
+        channel="EMAIL",
+        subject="s",
+        body_preview="b",
+    )
+
+
+@pytest.mark.asyncio
+async def test_mark_sent_is_idempotent(db_session_with_users):
+    """mark_sent を複数回呼んでも attempts は 1 のまま、状態も保たれる。"""
+    repo = NotificationDeliveryRepository(db_session_with_users)
+    delivery = await _make_pending(db_session_with_users)
+
+    await repo.mark_sent(delivery)
+    first_sent_at = delivery.sent_at
+    assert delivery.status == "SENT"
+    assert delivery.attempts == 1
+
+    # 2 回目呼び出しは no-op (PENDING ではないため)
+    await repo.mark_sent(delivery)
+    assert delivery.status == "SENT"
+    assert delivery.attempts == 1  # NOT 2
+    assert delivery.sent_at == first_sent_at  # 上書きされない
+
+
+@pytest.mark.asyncio
+async def test_mark_failed_is_idempotent(db_session_with_users):
+    repo = NotificationDeliveryRepository(db_session_with_users)
+    delivery = await _make_pending(db_session_with_users)
+
+    await repo.mark_failed(delivery, "first error")
+    assert delivery.status == "FAILED"
+    assert delivery.attempts == 1
+    first_error = delivery.error_detail
+
+    await repo.mark_failed(delivery, "second error")
+    assert delivery.status == "FAILED"
+    assert delivery.attempts == 1
+    assert delivery.error_detail == first_error  # 上書きされない
+
+
+@pytest.mark.asyncio
+async def test_mark_failed_after_mark_sent_is_noop(db_session_with_users):
+    """mark_sent 後に mark_failed を呼んでも SENT 状態は破壊されない。"""
+    repo = NotificationDeliveryRepository(db_session_with_users)
+    delivery = await _make_pending(db_session_with_users)
+
+    await repo.mark_sent(delivery)
+    await repo.mark_failed(delivery, "should not apply")
+    assert delivery.status == "SENT"
+    assert delivery.attempts == 1
+    assert delivery.error_detail is None
+
+
+@pytest.mark.asyncio
+async def test_mark_sent_after_mark_failed_is_noop(db_session_with_users):
+    repo = NotificationDeliveryRepository(db_session_with_users)
+    delivery = await _make_pending(db_session_with_users)
+
+    await repo.mark_failed(delivery, "boom")
+    await repo.mark_sent(delivery)
+    assert delivery.status == "FAILED"
+    assert delivery.sent_at is None
+
+
+# ── サニタイザ単体 ──────────────────────────────────────────────
+
+
+def test_sanitize_removes_email_addresses():
+    raw = (
+        "SMTPRecipientsRefused: recipient user@example.com rejected by "
+        "admin@example.com server"
+    )
+    cleaned = _sanitize_error_detail(raw)
+    assert "user@example.com" not in cleaned
+    assert "admin@example.com" not in cleaned
+    assert "[redacted-email]" in cleaned
+    assert "SMTPRecipientsRefused" in cleaned  # exception type 情報は残す
+
+
+def test_sanitize_redacts_smtp_response_detail():
+    raw = "SMTPResponseException: 550 5.1.1 User unknown in virtual mailbox table"
+    cleaned = _sanitize_error_detail(raw)
+    # SMTP code は残す
+    assert "550" in cleaned or "5.1.1" in cleaned
+    # server-supplied detail は削除される
+    assert "User unknown" not in cleaned
+    assert "[redacted]" in cleaned
+
+
+def test_sanitize_caps_length_at_1000():
+    raw = "X" * 5000
+    cleaned = _sanitize_error_detail(raw)
+    assert len(cleaned) <= 1000
+
+
+def test_sanitize_preserves_exception_type_name():
+    raw = "ConnectionRefusedError: refused"
+    cleaned = _sanitize_error_detail(raw)
+    assert "ConnectionRefusedError" in cleaned
+
+
+@pytest.mark.asyncio
+async def test_mark_failed_sanitizes_error_detail_in_db(db_session_with_users):
+    """end-to-end: mark_failed 経由で DB に保存された値がサニタイズ済み。"""
+    repo = NotificationDeliveryRepository(db_session_with_users)
+    delivery = await _make_pending(db_session_with_users)
+
+    await repo.mark_failed(
+        delivery,
+        "SMTPRecipientsRefused: leaked@test.example.com rejected",
+    )
+
+    # 実際に DB から再取得して検証
+    result = await db_session_with_users.execute(
+        select(NotificationDelivery).where(NotificationDelivery.id == delivery.id)
+    )
+    row = result.scalar_one()
+    assert "leaked@test.example.com" not in (row.error_detail or "")
+    assert "[redacted-email]" in (row.error_detail or "")
+
+
+@pytest.mark.asyncio
+async def test_create_pending_uses_default_attempts_zero(db_session_with_users):
+    delivery = await _make_pending(db_session_with_users)
+    assert delivery.attempts == 0
+    assert delivery.status == "PENDING"
+    assert delivery.sent_at is None
+    assert delivery.error_detail is None
+    assert isinstance(delivery.id, uuid.UUID)

--- a/backend/tests/unit/test_notification_dispatcher.py
+++ b/backend/tests/unit/test_notification_dispatcher.py
@@ -1,0 +1,369 @@
+"""NotificationDispatcher のユニットテスト
+
+EmailSender と TemplateRenderer を依存注入でフェイク差し替えし、
+Dispatcher のオーケストレーション (事前書き込み・購読判定・成功/失敗遷移)
+を検証する。SQLite インメモリ DB を使う。
+"""
+
+from dataclasses import dataclass
+
+import pytest
+from sqlalchemy import select
+
+from app.models.notification_delivery import NotificationDelivery
+from app.models.notification_preference import NotificationPreference
+from app.services.notification_dispatcher import NotificationDispatcher
+from app.services.notification_senders.email_sender import SendResult
+from app.services.notification_templates.renderer import RenderedEmail
+from tests.conftest import ADMIN_USER_ID, PM_USER_ID, VIEWER_USER_ID
+
+
+class _FakeEmailSender:
+    """SendResult を事前に仕込めるフェイク。"""
+
+    def __init__(self, result: SendResult | None = None) -> None:
+        self.result = result or SendResult(ok=True)
+        self.sent: list[dict] = []
+
+    async def send(
+        self,
+        *,
+        to: str,
+        subject: str,
+        body_text: str,
+        body_html: str | None = None,
+    ) -> SendResult:
+        self.sent.append(
+            {
+                "to": to,
+                "subject": subject,
+                "body_text": body_text,
+                "body_html": body_html,
+            }
+        )
+        return self.result
+
+
+@dataclass
+class _FakeRenderer:
+    """常に固定の RenderedEmail を返すフェイク。"""
+
+    subject: str = "Subject X"
+    body_text: str = "Body text X"
+    body_html: str | None = "<p>HTML X</p>"
+
+    def render_email(self, event_key: str, context: dict) -> RenderedEmail:
+        return RenderedEmail(
+            subject=f"{self.subject} [{event_key}]",
+            body_text=self.body_text,
+            body_html=self.body_html,
+        )
+
+
+async def _set_pref(
+    db_session_with_users,
+    user_id,
+    *,
+    email_enabled: bool,
+    event_key: str,
+    subscribed_to_email: bool,
+) -> None:
+    pref = NotificationPreference(
+        user_id=user_id,
+        email_enabled=email_enabled,
+        slack_enabled=False,
+        events={event_key: {"email": subscribed_to_email, "slack": False}},
+    )
+    db_session_with_users.add(pref)
+    await db_session_with_users.flush()
+
+
+async def _get_deliveries(db_session_with_users) -> list[NotificationDelivery]:
+    result = await db_session_with_users.execute(
+        select(NotificationDelivery).order_by(NotificationDelivery.created_at)
+    )
+    return list(result.scalars().all())
+
+
+@pytest.mark.asyncio
+async def test_dispatch_sends_to_subscribed_user_success_path(db_session_with_users):
+    """購読済みユーザー 1 名: delivery=SENT で完走する。"""
+    await _set_pref(
+        db_session_with_users,
+        ADMIN_USER_ID,
+        email_enabled=True,
+        event_key="daily_report_submitted",
+        subscribed_to_email=True,
+    )
+    fake_sender = _FakeEmailSender(result=SendResult(ok=True))
+    dispatcher = NotificationDispatcher(
+        db_session_with_users,
+        email_sender=fake_sender,  # type: ignore[arg-type]
+        template_renderer=_FakeRenderer(),  # type: ignore[arg-type]
+    )
+
+    deliveries = await dispatcher.dispatch(
+        event_key="daily_report_submitted",
+        user_ids=[ADMIN_USER_ID],
+        context={"report_id": "r1"},
+    )
+
+    assert len(deliveries) == 1
+    assert deliveries[0].status == "SENT"
+    assert deliveries[0].sent_at is not None
+    assert deliveries[0].channel == "EMAIL"
+    assert deliveries[0].attempts == 1
+    # EmailSender に届いた内容検証
+    assert len(fake_sender.sent) == 1
+    assert fake_sender.sent[0]["to"] == "admin@test.example.com"
+    assert "daily_report_submitted" in fake_sender.sent[0]["subject"]
+
+
+@pytest.mark.asyncio
+async def test_dispatch_skips_unsubscribed_user(db_session_with_users):
+    """event_prefs.email == False のユーザーには送信されない。"""
+    await _set_pref(
+        db_session_with_users,
+        ADMIN_USER_ID,
+        email_enabled=True,
+        event_key="daily_report_submitted",
+        subscribed_to_email=False,  # この event には購読していない
+    )
+    fake_sender = _FakeEmailSender()
+    dispatcher = NotificationDispatcher(
+        db_session_with_users,
+        email_sender=fake_sender,  # type: ignore[arg-type]
+        template_renderer=_FakeRenderer(),  # type: ignore[arg-type]
+    )
+
+    deliveries = await dispatcher.dispatch(
+        event_key="daily_report_submitted",
+        user_ids=[ADMIN_USER_ID],
+        context={},
+    )
+
+    assert deliveries == []
+    assert fake_sender.sent == []
+    # 事前書き込みも発生していない (購読判定は書き込み前に行うため)
+    assert await _get_deliveries(db_session_with_users) == []
+
+
+@pytest.mark.asyncio
+async def test_dispatch_skips_email_globally_disabled(db_session_with_users):
+    """email_enabled=False のユーザーはイベント購読に関わらず送信されない。"""
+    await _set_pref(
+        db_session_with_users,
+        ADMIN_USER_ID,
+        email_enabled=False,
+        event_key="daily_report_submitted",
+        subscribed_to_email=True,
+    )
+    fake_sender = _FakeEmailSender()
+    dispatcher = NotificationDispatcher(
+        db_session_with_users,
+        email_sender=fake_sender,  # type: ignore[arg-type]
+        template_renderer=_FakeRenderer(),  # type: ignore[arg-type]
+    )
+
+    deliveries = await dispatcher.dispatch(
+        event_key="daily_report_submitted",
+        user_ids=[ADMIN_USER_ID],
+        context={},
+    )
+
+    assert deliveries == []
+    assert fake_sender.sent == []
+
+
+@pytest.mark.asyncio
+async def test_dispatch_skips_user_without_preference_row(db_session_with_users):
+    """preferences レコードが無いユーザーは送信対象外。"""
+    fake_sender = _FakeEmailSender()
+    dispatcher = NotificationDispatcher(
+        db_session_with_users,
+        email_sender=fake_sender,  # type: ignore[arg-type]
+        template_renderer=_FakeRenderer(),  # type: ignore[arg-type]
+    )
+
+    deliveries = await dispatcher.dispatch(
+        event_key="daily_report_submitted",
+        user_ids=[ADMIN_USER_ID],
+        context={},
+    )
+
+    assert deliveries == []
+    assert fake_sender.sent == []
+
+
+@pytest.mark.asyncio
+async def test_dispatch_marks_failed_on_send_error(db_session_with_users):
+    """Email 送信失敗時は delivery=FAILED, error_detail が記録される。"""
+    await _set_pref(
+        db_session_with_users,
+        ADMIN_USER_ID,
+        email_enabled=True,
+        event_key="daily_report_submitted",
+        subscribed_to_email=True,
+    )
+    fake_sender = _FakeEmailSender(
+        result=SendResult(ok=False, error="ConnectionRefusedError: boom")
+    )
+    dispatcher = NotificationDispatcher(
+        db_session_with_users,
+        email_sender=fake_sender,  # type: ignore[arg-type]
+        template_renderer=_FakeRenderer(),  # type: ignore[arg-type]
+    )
+
+    deliveries = await dispatcher.dispatch(
+        event_key="daily_report_submitted",
+        user_ids=[ADMIN_USER_ID],
+        context={},
+    )
+
+    assert len(deliveries) == 1
+    assert deliveries[0].status == "FAILED"
+    assert deliveries[0].sent_at is None
+    assert deliveries[0].error_detail is not None
+    assert "ConnectionRefusedError" in deliveries[0].error_detail
+    assert deliveries[0].attempts == 1
+
+
+@pytest.mark.asyncio
+async def test_dispatch_writes_pending_row_before_send(db_session_with_users):
+    """事前書き込み: Sender 呼出時点で delivery 行が存在している。"""
+    await _set_pref(
+        db_session_with_users,
+        ADMIN_USER_ID,
+        email_enabled=True,
+        event_key="daily_report_submitted",
+        subscribed_to_email=True,
+    )
+
+    observed_row_count: list[int] = []
+
+    class _ObservingSender:
+        async def send(self, **kwargs) -> SendResult:
+            # Sender に入った瞬間の delivery 行数を記録
+            result = await db_session_with_users.execute(select(NotificationDelivery))
+            observed_row_count.append(len(list(result.scalars().all())))
+            return SendResult(ok=True)
+
+    dispatcher = NotificationDispatcher(
+        db_session_with_users,
+        email_sender=_ObservingSender(),  # type: ignore[arg-type]
+        template_renderer=_FakeRenderer(),  # type: ignore[arg-type]
+    )
+
+    await dispatcher.dispatch(
+        event_key="daily_report_submitted",
+        user_ids=[ADMIN_USER_ID],
+        context={},
+    )
+
+    # 送信前に 1 行書き込まれていたことを確認 (事前書き込み契約)
+    assert observed_row_count == [1]
+
+
+@pytest.mark.asyncio
+async def test_dispatch_multiple_users_mixed_subscription(db_session_with_users):
+    """複数ユーザー: 購読/非購読/未設定の混在で適切にフィルタされる。"""
+    await _set_pref(
+        db_session_with_users,
+        ADMIN_USER_ID,
+        email_enabled=True,
+        event_key="daily_report_submitted",
+        subscribed_to_email=True,
+    )
+    await _set_pref(
+        db_session_with_users,
+        VIEWER_USER_ID,
+        email_enabled=True,
+        event_key="daily_report_submitted",
+        subscribed_to_email=False,  # 非購読
+    )
+    # PM_USER_ID は preferences レコード未作成
+
+    fake_sender = _FakeEmailSender()
+    dispatcher = NotificationDispatcher(
+        db_session_with_users,
+        email_sender=fake_sender,  # type: ignore[arg-type]
+        template_renderer=_FakeRenderer(),  # type: ignore[arg-type]
+    )
+
+    deliveries = await dispatcher.dispatch(
+        event_key="daily_report_submitted",
+        user_ids=[ADMIN_USER_ID, VIEWER_USER_ID, PM_USER_ID],
+        context={},
+    )
+
+    # ADMIN のみに送信される
+    assert len(deliveries) == 1
+    assert deliveries[0].user_id == ADMIN_USER_ID
+    assert len(fake_sender.sent) == 1
+
+
+@pytest.mark.asyncio
+async def test_dispatch_empty_user_list(db_session_with_users):
+    dispatcher = NotificationDispatcher(
+        db_session_with_users,
+        email_sender=_FakeEmailSender(),  # type: ignore[arg-type]
+        template_renderer=_FakeRenderer(),  # type: ignore[arg-type]
+    )
+    result = await dispatcher.dispatch(event_key="x", user_ids=[], context={})
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_send_ping_bypasses_subscription(db_session_with_users):
+    """疎通テスト: preferences 未設定でも強制送信される。"""
+    fake_sender = _FakeEmailSender()
+    dispatcher = NotificationDispatcher(
+        db_session_with_users,
+        email_sender=fake_sender,  # type: ignore[arg-type]
+        template_renderer=_FakeRenderer(),  # type: ignore[arg-type]
+    )
+
+    # User モデルを実 DB から取得
+    from sqlalchemy import select as _select
+
+    from app.models.user import User
+
+    user = (
+        await db_session_with_users.execute(
+            _select(User).where(User.id == ADMIN_USER_ID)
+        )
+    ).scalar_one()
+
+    delivery = await dispatcher.send_ping(user=user)
+
+    assert delivery.status == "SENT"
+    assert delivery.event_key == "ping"
+    assert len(fake_sender.sent) == 1
+    assert fake_sender.sent[0]["to"] == "admin@test.example.com"
+
+
+@pytest.mark.asyncio
+async def test_body_preview_is_truncated_to_500_chars(db_session_with_users):
+    await _set_pref(
+        db_session_with_users,
+        ADMIN_USER_ID,
+        email_enabled=True,
+        event_key="x",
+        subscribed_to_email=True,
+    )
+    long_body = "A" * 1000
+    fake_sender = _FakeEmailSender()
+    dispatcher = NotificationDispatcher(
+        db_session_with_users,
+        email_sender=fake_sender,  # type: ignore[arg-type]
+        template_renderer=_FakeRenderer(body_text=long_body),  # type: ignore[arg-type]
+    )
+
+    deliveries = await dispatcher.dispatch(
+        event_key="x",
+        user_ids=[ADMIN_USER_ID],
+        context={},
+    )
+
+    assert deliveries[0].body_preview is not None
+    assert len(deliveries[0].body_preview) == 500

--- a/docs/03_設計（Design）/07_通知機能設計（Notification Feature）.md
+++ b/docs/03_設計（Design）/07_通知機能設計（Notification Feature）.md
@@ -165,7 +165,7 @@ ServiceHub Construction Platform は工事案件 / 日報 / 安全品質 / ITSM 
 
 ## 9. Phase 2 設計（実送信基盤）
 
-**ステータス**: 未実装。次セッション以降で着手予定。
+**ステータス**: **Phase 2a 実装中（PR #95）** / 2b–2d 未着手
 
 ### 9.1 目的と受入れ条件
 
@@ -173,9 +173,9 @@ Phase 1 で設定されたユーザー購読に従って、ドメインイベン
 
 **受入れ条件**:
 - 購読済みイベントが発生したとき、対応チャンネルに通知が届く
-- 配信失敗時も業務ロジックをブロックしない（fire-and-forget）
-- 配信ログが保存され、後から追跡可能
-- 送信失敗時のリトライ機構が働く
+- 配信失敗時も業務ロジックをブロックしない（fire-and-forget、Phase 2b 以降で完全対応）
+- 配信ログが保存され、後から追跡可能（durable tracking — Phase 2a で自己トランザクション境界を持つ暫定実装）
+- 送信失敗時のリトライ機構が働く（Phase 2d で実装、`failure_kind=transient` のみ対象）
 - Phase 1 の preferences 設定のみで購読 ON/OFF が制御できる
 
 ### 9.2 アーキテクチャ選定
@@ -198,13 +198,61 @@ Phase 1 で設定されたユーザー購読に従って、ドメインイベン
 
 ### 9.3 技術選定の候補と推奨
 
-| 領域 | 候補 A | 候補 B | 推奨 |
+| 領域 | 候補 A | 候補 B | 採用 / 実装状況 |
 |---|---|---|---|
-| Email ライブラリ | `aiosmtplib` (非同期 SMTP) | SendGrid / Mailgun API | **aiosmtplib** (外部依存少、開発環境で Mailhog に差し替え容易) |
-| Slack 送信 | Incoming Webhook (httpx POST) | Slack SDK (async) | **Incoming Webhook** (シンプル、ユーザー設定済 URL を使うだけ) |
-| 非同期実行 | FastAPI `BackgroundTasks` | Celery / RQ + Redis | **BackgroundTasks** (Phase 2 は軽量運用、Celery は Phase 3 以降で検討) |
-| テンプレート | Jinja2 | f-string ベタ書き | **Jinja2** (将来的な多言語対応・HTML メール対応のため) |
-| リトライ | 同期 3 回リトライ | 専用ジョブキュー | **同期 3 回** (Phase 2 スコープに収めるため) |
+| Email ライブラリ | `aiosmtplib` (非同期 SMTP) | SendGrid / Mailgun API | **aiosmtplib==3.0.2** — Phase 2a で採用済み。開発は Mailhog 互換 (port 1025, TLS なし) |
+| Slack 送信 | Incoming Webhook (httpx POST) | Slack SDK (async) | **Incoming Webhook** — Phase 2b で実装予定 |
+| 非同期実行 | FastAPI `BackgroundTasks` | Celery / RQ + Redis | **BackgroundTasks** — **Phase 2b で統合予定** (Phase 2a は同期 MVP) |
+| テンプレート | Jinja2 | f-string ベタ書き | **Jinja2==3.1.4 + StrictUndefined** — Phase 2a で採用済み |
+| リトライ | 同期 3 回リトライ | 専用ジョブキュー | **同期 3 回 + `failure_kind=transient` フィルタ** — Phase 2d |
+
+### 9.3.1 実装判断事項 (Phase 2a で確定したもの)
+
+#### SendResult 戻り値契約 + failure_kind 分類
+
+`EmailSender.send()` は例外を呼び出し側に伝播せず、`SendResult(ok, error, failure_kind)` を返す。`failure_kind` は Phase 2d のリトライ判定に直結するため、Phase 2a の時点で型を固定した:
+
+- **`transient`**: 接続失敗、タイムアウト、ServerDisconnected、OSError (DNS 等)、SMTP 4xx 応答 → Phase 2d で再試行対象
+- **`permanent`**: 認証失敗、宛先無効、SMTP 5xx 応答 → Phase 2d では再試行しない
+- **未知例外**: 安全側で `permanent` デフォルト (optimistic retry で SMTP/ユーザーに迷惑をかけない)
+
+#### サニタイザ方針
+
+`notification_deliveries.error_detail` は raw SMTP エラー文字列のまま保存しない。`_sanitize_error_detail()` が以下を redact:
+- メールアドレスパターン → `[redacted-email]`
+- SMTP レスポンスコードに続く server-supplied detail → `<code> [redacted]`（RFC コード部分だけ残す）
+- 先頭 1000 文字で cap
+
+詳細な失敗原因は外部 structured logging (Phase 2d で導入) に残し、DB の `error_detail` は「admin が読む粒度」の要約とする。
+
+#### send_ping の購読バイパス
+
+`NotificationDispatcher.send_ping(user)` は購読判定をバイパスする。ユーザーが「自分の購読設定が効いているか」を検証する機能なので「設定 OFF → 届かない」動作では意図が通らない。実装では `dispatch()` (購読あり) と `send_ping()` (購読なし強制) を責務分離し、フラグによる条件分岐を避ける。
+
+### 9.3.2 Phase 2a の暫定設計: 自己トランザクション境界（重要）
+
+Phase 2a の `NotificationDispatcher` は **既存 Service/Repository 規約 (commit は呼び出し側が持つ) からの意図的逸脱**として、dispatch 内で明示的に `db.commit()` を呼ぶ。
+
+```
+_dispatch_email フロー:
+  1. render
+  2. create_pending (PENDING 行挿入, flush)
+  3. db.commit()  ← Commit #1: PENDING を durable に
+  4. EmailSender.send()  ← 外部 I/O、ここでクラッシュしても PENDING は残る
+  5. mark_sent or mark_failed (status 更新, flush)
+  6. db.commit()  ← Commit #2: 終了状態を durable に
+```
+
+**理由**: §9.1 の durable tracking 要件を満たすには、外部 I/O の前に delivery 行が確定している必要がある。flush() だけでは呼び出し側の rollback で消える可能性があり、「送信されたのに記録なし」の状態が発生しうる。
+
+**Phase 2b 以降の解消方針**: `BackgroundTasks` 統合により、dispatcher を **独立 session** で実行する形に移行する。独立 session であれば自分で transaction 境界を持つことが自然になり、呼び出し側の request-scoped session を侵食しなくなる。
+
+### 9.3.3 冪等な状態遷移
+
+`mark_sent` / `mark_failed` は `status == "PENDING"` の行のみ遷移させる。既に `SENT`/`FAILED` の行に対しては silent no-op。これにより:
+- Phase 2d のリトライワーカーが誤って SENT 済みの行を再遷移しない
+- 二重実行でも `attempts` が二重増加しない
+- terminal state (SENT/FAILED) が上書きされない
 
 ### 9.4 Phase 2 データモデル
 
@@ -265,22 +313,28 @@ notification_templates/
 ### 9.8 セキュリティ / プライバシー
 
 - Webhook URL は Phase 1 では平文保存。Phase 2 では **暗号化 at rest** を検討（`cryptography.fernet` + KEK）
-- 配信ログに PII を残しすぎない（body_preview は 500 文字まで）
-- 送信失敗時のスタックトレースは `error_detail` に保存するが、ユーザーの個人情報が含まれないようサニタイズ
-- ADMIN ログ閲覧時の監査ログ (`audit_logs`) への記録
+- 配信ログに PII を残しすぎない（body_preview は 500 文字まで）— **Phase 2a で実装済み**
+- 送信失敗時のエラー内容は `error_detail` に保存するが、メールアドレスや SMTP サーバー応答詳細はサニタイズ — **Phase 2a で `_sanitize_error_detail()` 実装済み** (§9.3.1 参照)
+- ADMIN ログ閲覧時の監査ログ (`audit_logs`) への記録 — Phase 2d で統合
 
 ### 9.9 段階的リリース方針
 
 Phase 2 はさらに以下に細分化:
 
-| サブフェーズ | 内容 | 見積 |
-|---|---|---|
-| **2a** | `NotificationDispatcher` + `notification_deliveries` + Email 送信 (MVP) | 1 セッション |
-| **2b** | Slack 送信 + 設定ページから疎通テストボタン | 1 セッション |
-| **2c** | ドメインイベントフック統合 (5 イベント種別) + E2E テスト | 1 セッション |
-| **2d** | リトライ機構 + 監査ログ統合 | 0.5 セッション |
+| サブフェーズ | 内容 | ステータス | 見積 |
+|---|---|---|---|
+| **2a** | `NotificationDispatcher` + `notification_deliveries` + Email 送信 (同期 MVP) | 🟡 **PR #95 レビュー中** | 1 セッション |
+| **2b** | Slack 送信 + `POST /notifications/test` + **BackgroundTasks 統合 (self-commit 解消)** | ⏳ 未着手 | 1 セッション |
+| **2c** | ドメインイベントフック統合 (5 イベント種別) + E2E テスト | ⏳ 未着手 | 1 セッション |
+| **2d** | リトライ機構 (`failure_kind=transient` スキャン) + 監査ログ統合 | ⏳ 未着手 | 0.5 セッション |
 
 **2a, 2b はバックエンド中心で独立してマージ可**。2c 以降で既存業務サービスを触るため慎重に進める。
+
+**Phase 2b で必ず行うこと** (9.3.2 自己トランザクション境界の解消):
+- `NotificationDispatcher` を `BackgroundTasks` 経由で呼び出す形に変更
+- 独立 `AsyncSession` を使い、呼び出し側 request-scoped session を侵食しないようにする
+- dispatcher の docstring から「例外的責務」の注意書きを削除
+- 既存テストは `BackgroundTasks` のモックで引き続き動作可能なようにする
 
 ### 9.10 Phase 2 の非スコープ（Phase 3 以降）
 

--- a/state.json
+++ b/state.json
@@ -1,15 +1,15 @@
 {
-  "phase": "Phase 2 - 機能強化（Day 7 完了間近 — 通知Phase1 完全消化）",
-  "loop": "Day7-Improve-Final",
-  "loop_count": 68,
+  "phase": "Phase 2 - 機能強化（Day 8 開始 — 通知Phase2a Dispatcher+Email 実装中）",
+  "loop": "Day8-Verify-PR95",
+  "loop_count": 69,
   "status": "stable",
-  "last_updated": "2026-04-10T17:10:00+09:00",
+  "last_updated": "2026-04-11T17:56:00+09:00",
   "execution": {
-    "start_time": "2026-04-10T14:19:00+09:00",
+    "start_time": "2026-04-11T17:41:00+09:00",
     "max_duration_minutes": 300,
-    "elapsed_minutes": 171,
-    "remaining_minutes": 129,
-    "phase": "Improve",
+    "elapsed_minutes": 15,
+    "remaining_minutes": 285,
+    "phase": "Verify",
     "auto_stop_threshold": 5,
     "graceful_shutdown": false
   },
@@ -58,10 +58,10 @@
     "stability": "stable"
   },
   "metrics": {
-    "test_count_backend": 199,
+    "test_count_backend": 239,
     "test_count_frontend": 263,
     "test_count_e2e": 165,
-    "test_total": 627,
+    "test_total": 667,
     "coverage_backend": "96%",
     "coverage_frontend": "88%",
     "ci_status": "green",
@@ -185,6 +185,60 @@
         "immediate": "完了（PR#81マージ済み）",
         "next_task": "通知機能検討 or E2Eテスト拡充（usersページ・設定ページ）",
         "backlog": ["通知機能（メール/Slack）", "パフォーマンス計測基盤", "ダークモード対応", "i18n基盤検討"]
+      }
+    },
+    "day8_2026_04_11": {
+      "date": "2026-04-11",
+      "status": "in_progress",
+      "hours_so_far": 1.5,
+      "loops_completed": 2,
+      "prs_opened": ["#95"],
+      "prs_merged": [],
+      "issues_progress": {"#94": "Phase 2a 実装 + Codex review fix + 設計ドキュメント更新 (PR#95 CI green 待ち)"},
+      "commits_to_branch": 3,
+      "highlights": [
+        "PR#95 c641886: 通知機能 Phase 2a — NotificationDispatcher + EmailSender + Jinja2 テンプレ基盤 (16 files, +1082 lines)",
+        "PR#95 Codex adversarial review: 4 件の major 指摘 (durable tracking / fire-and-forget / PII / 冪等性)",
+        "PR#95 7516d75 fix: Codex 指摘 4 件に対応 — Option A (同期 MVP + 必須安全性) で最小修正",
+        "  - Repository: mark_sent/mark_failed に PENDING guard で冪等化",
+        "  - Repository: _sanitize_error_detail() で email / SMTP response を redact",
+        "  - EmailSender: SendResult に failure_kind: Literal['transient','permanent'] 追加、_classify() で分類",
+        "  - Dispatcher: _dispatch_email で明示 commit() を 2 回呼び durable tracking を確保 (自己 transaction 境界)",
+        "  - 新規 25 tests (test_notification_delivery_repo 10 + test_email_sender_classification 15)",
+        "PR#95 5401dd1 docs: 07_通知機能設計.md §9 を Phase 2a 実装後の学びで更新",
+        "  - §9.3.1 実装判断事項 (failure_kind 型固定 / サニタイザ方針 / send_ping 購読バイパス根拠)",
+        "  - §9.3.2 自己 transaction 境界の設計意図と Phase 2b で BackgroundTasks 統合で解消する計画",
+        "  - §9.3.3 冪等な状態遷移",
+        "  - §9.9 サブフェーズ表にステータス列追加、Phase 2b 必須作業を明文化",
+        "backend 全 unit tests 121/121 pass (+25)、regression 0、ruff clean (130 files)"
+      ],
+      "metrics_delta": {
+        "tests_backend": "+40 (199 → 239)",
+        "tests_total": "+40 (627 → 667)",
+        "new_files": 15,
+        "lines_added_total": 1575,
+        "new_tables": 1,
+        "new_dependencies": 2,
+        "codex_review_cycles": 1,
+        "commits_on_branch": 3
+      },
+      "design_decisions": {
+        "1_dispatcher_return_contract": "A (原 B) — Phase 2a は同期 MVP、fire-and-forget は Phase 2b で BackgroundTasks 統合",
+        "2_sender_error_handling": "B+ — SendResult(ok, error, failure_kind) で transient/permanent 分類",
+        "3_delivery_write_timing": "A+ — 事前書き込み + 自己 commit で durable tracking 確保 (Phase 2a 暫定)",
+        "4_idempotency": "PENDING guard による silent no-op",
+        "5_pii_sanitization": "regex redact (email + SMTP response) — §9.8 準拠",
+        "6_failure_classification": "SMTP 階層例外 + OSError ファミリ + 4xx/5xx + unknown→permanent safe default"
+      },
+      "codex_review": {
+        "first_review": "REQUEST_CHANGES - 4 major (durable/fire-forget/PII/idempotency)",
+        "fix_commit": "7516d75",
+        "re_review": "in progress"
+      },
+      "resume_point": {
+        "immediate": "Codex re-review 待ち、LGTM で PR#95 merge → Phase 2b 着手",
+        "next_task": "Phase 2b: SlackSender + POST /notifications/test + BackgroundTasks 統合 (self-commit 解消)",
+        "backlog": ["Phase 2c: ドメインイベントフック統合", "Phase 2d: リトライ + 監査ログ", "パフォーマンス計測基盤"]
       }
     },
     "day7_2026_04_10": {


### PR DESCRIPTION
## Summary

Issue #94 の Phase 2a: NotificationDispatcher + Email 送信 **synchronous MVP**。独立マージ可能な最初のサブフェーズ。**Phase 2a は同期実装であり、BackgroundTasks 統合は Phase 2b で行う**。リトライ機構は Phase 2d で段階実装する。

> **更新履歴**
> - `c641886` — Phase 2a 初回実装
> - `7516d75` — Codex adversarial review 指摘 4 件の major fix (冪等性 / PII サニタイズ / 例外分類 / durable tracking)
> - `5401dd1` — 設計ドキュメント §9 を Phase 2a 実装後の学びで更新
> - `29f92bc` — state.json / README.md に Day 8 実績反映
>
> **Codex re-review: READY WITH NITS** — 4 major 指摘は全て RESOLVED。残る nit は文書整合のみで merge blocker ではない。

## 変更内容

### 追加コンポーネント
| 層 | ファイル | 役割 |
|---|---|---|
| Model | `notification_delivery.py` | 配信ログ (PENDING/SENT/FAILED 遷移) |
| Migration | `alembic/versions/0009_notification_deliveries.py` | テーブル + 2 indexes |
| Repository | `notification_delivery.py` | `create_pending` / `mark_sent` / `mark_failed` (**冪等 guard** + **PII サニタイザ**) |
| Service | `notification_dispatcher.py` | 購読判定 → 事前書き込み → **commit** → Sender 呼出 → **commit** (自己トランザクション境界) |
| Infra | `notification_senders/email_sender.py` | aiosmtplib ラッパ、**SendResult(ok, error, failure_kind)** 戻り値 + 例外分類 |
| Template | `notification_templates/renderer.py` | Jinja2, StrictUndefined |
| Config | `core/config.py` (SMTP_*) | Mailhog 互換デフォルト |

### 設計判断 (Phase 2a 実装後の確定版)
- **synchronous MVP**: Phase 2a は **同期実装**。呼び出し側は SMTP レイテンシで一時ブロックされる。fire-and-forget（caller が待機しない）は Phase 2b で `BackgroundTasks` 統合により実現する
- **自己トランザクション境界**: `NotificationDispatcher._dispatch_email` は外部 I/O の前後で自ら `db.commit()` を呼び、PENDING 行を durable に残す。これは §9.1 / §9.4 の durable tracking 要件を満たすための **Phase 2a 限定の例外的責務** (docstring 明記)。Phase 2b で独立 session に移行することで解消
- **事前書き込み**: 送信前に PENDING を commit、終了状態 (SENT/FAILED) は PENDING guard で冪等化 → Phase 2d の RETRY スキャンで安全に回収可能
- **失敗分類**: `SendResult.failure_kind: Literal["transient", "permanent"]`
  - transient: Connect/Timeout/ServerDisconnected/OSError/SMTP 4xx → Phase 2d 再試行対象
  - permanent: Auth/Recipient/Sender/Data/SMTP 5xx → 再試行しない
  - 未知例外: 安全側で permanent (optimistic retry を防ぐ)
- **PII サニタイズ**: `_sanitize_error_detail()` で error_detail のメールアドレス・SMTP サーバー応答を redact (§9.8 準拠)
- **冪等状態遷移**: `mark_sent` / `mark_failed` は `status=PENDING` guard で silent no-op、重複コール時の attempts 二重増加と terminal state 上書きを防ぐ
- **依存注入**: EmailSender / TemplateRenderer はコンストラクタ注入でフェイク化可能
- **送信強制 API 分離**: `dispatch` (購読判定あり) と `send_ping` (購読判定なし強制送信) を分ける

## テスト結果

| Scope | Count | Result |
|---|---|---|
| **Phase 2a 全 unit tests** | **40** | ✅ all pass (13.17s) |
| └ test_email_sender.py | 5 | ✅ |
| └ test_notification_dispatcher.py | 10 | ✅ |
| └ **test_notification_delivery_repo.py** (Codex fix) | **10** | ✅ |
| └ **test_email_sender_classification.py** (Codex fix) | **15** | ✅ |
| backend unit tests (full) | **121** | ✅ all pass (43.67s) |
| Regression | - | ✅ 0 |
| ruff check / format (130 files) | - | ✅ clean |
| CI (GitHub Actions) | 5/5 | ✅ all pass |
| Codex review | - | ✅ READY WITH NITS |

### 新規テスト網羅範囲 (40 件)

#### 初回 15 件
- 成功パス (SENT 遷移、attempts=1、sent_at 記録)
- 購読判定: event 購読 OFF / email_enabled=False / preferences 未作成
- 失敗パス (FAILED 遷移、error_detail 記録)
- 事前書き込み順序の観察型テスト
- 複数ユーザー混在、空リスト、body_preview 500 文字切り詰め
- send_ping の購読バイパス契約
- EmailSender の例外吸収 / multipart/alternative 組み立て

#### Codex review 対応 25 件
- **冪等性 10 件**: mark_sent/mark_failed 重複コール・cross transition・DB 到達サニタイズ
- **失敗分類 15 件**: transient 7 (Connect/Timeout/OSError 他) + permanent 2 (Auth/Recipient) + 4xx/5xx 分岐 + 未知例外 + send() 伝播

## 影響範囲

- ✅ **backend のみ** (frontend 未変更)
- ✅ 既存 Service 層への侵襲ゼロ (フック結線は Phase 2c)
- ✅ 既存 Phase 1 機能は無変更
- ➕ 依存追加: `aiosmtplib==3.0.2`, `jinja2==3.1.4`
- ➕ DB schema: `notification_deliveries` テーブル (Alembic 0009)
- ➕ 環境変数 (任意): `SMTP_HOST`/`SMTP_PORT`/`SMTP_USERNAME`/`SMTP_PASSWORD`/`SMTP_USE_TLS`/`SMTP_USE_STARTTLS`/`SMTP_TIMEOUT_SECONDS`/`SMTP_FROM_ADDRESS`/`SMTP_FROM_NAME`
- ⚠️ **dispatcher が自己 commit を行う例外的責務**: 呼び出し側は `dispatch()` 内部で transaction が一度 commit されることを把握して呼ぶ必要がある (Phase 2b 以降で解消予定)

## 残課題 (後続サブフェーズ)

- **Phase 2b** (次 PR): Slack 送信 + `POST /api/v1/notifications/test` + **BackgroundTasks 統合 (self-commit 解消)**
- **Phase 2c**: ドメインイベントフック統合 (5 イベント) + E2E テスト
- **Phase 2d**: リトライ (`failure_kind=transient` スキャン) + 監査ログ統合

## Test Plan

- [x] Phase 2a unit tests 40/40 pass
- [x] backend 全 unit tests 121/121 pass
- [x] ruff check / format clean
- [x] Alembic 0008 → 0009 の chain 検証
- [x] Codex adversarial review 対応 commit push (`7516d75`)
- [x] CI (GitHub Actions) 5/5 all pass
- [x] Codex re-review: READY WITH NITS (merge 可決)

Closes #94 のうち Phase 2a (段階的 close、残りは 2b/2c/2d)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
