### PR TITLE
feat(notifications): Phase 2e — audit_logs 統合 (Issue #101)

### DIFF
--- a/backend/app/api/v1/routers/notifications.py
+++ b/backend/app/api/v1/routers/notifications.py
@@ -10,19 +10,32 @@ Phase 2d:
     GET /api/v1/notifications/deliveries
         ADMIN のみ利用可能な配信履歴 API。
         status, channel, event_key, user_id でフィルタリング可能。
+
+Phase 2e:
+    GET /api/v1/notifications/deliveries へのアクセスを audit_logs に記録。
+    action='READ', resource='notification_deliveries'
 """
 
 import math
 import uuid
 from typing import Annotated
 
-from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query, status
+from fastapi import (
+    APIRouter,
+    BackgroundTasks,
+    Depends,
+    HTTPException,
+    Query,
+    Request,
+    status,
+)
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.v1.deps import get_current_user
 from app.core.rbac import UserRole, require_roles
 from app.db.base import get_db
 from app.models.user import User
+from app.repositories.audit_log import AuditLogRepository
 from app.repositories.notification_delivery import NotificationDeliveryRepository
 from app.repositories.notification_preference import (
     NotificationPreferenceRepository,
@@ -108,6 +121,7 @@ async def post_notification_test(
     response_model=PaginatedResponse[NotificationDeliveryResponse],
 )
 async def list_notification_deliveries(
+    request: Request,
     db: Annotated[AsyncSession, Depends(get_db)],
     current_user: Annotated[User, Depends(require_roles(UserRole.ADMIN))],
     page: int = Query(default=1, ge=1),
@@ -127,7 +141,7 @@ async def list_notification_deliveries(
         page       - ページ番号 (1 始まり)
         per_page   - 1 ページあたり件数 (最大 100)
 
-    このエンドポイントへのアクセスは audit_logs に記録される (Phase 2d §9.8)。
+    このエンドポイントへのアクセスは audit_logs に記録される (Phase 2e)。
     """
     offset = (page - 1) * per_page
     repo = NotificationDeliveryRepository(db)
@@ -140,6 +154,24 @@ async def list_notification_deliveries(
         channel=filter_channel,
         event_key=filter_event_key,
         user_id=filter_user_id,
+    )
+
+    # ADMIN アクセスを audit_logs に記録 (ISO27001 §9.8)
+    await AuditLogRepository(db).create(
+        action="READ",
+        resource="notification_deliveries",
+        user_id=current_user.id,
+        after_data={
+            "page": page,
+            "per_page": per_page,
+            "filter_status": filter_status,
+            "filter_channel": filter_channel,
+            "filter_event_key": filter_event_key,
+            "filter_user_id": str(filter_user_id) if filter_user_id else None,
+            "total_returned": total,
+        },
+        ip_address=request.client.host if request.client else None,
+        user_agent=request.headers.get("user-agent"),
     )
 
     return PaginatedResponse(

--- a/backend/app/repositories/audit_log.py
+++ b/backend/app/repositories/audit_log.py
@@ -1,0 +1,58 @@
+"""監査ログリポジトリ (Phase 2e)
+
+AuditLog レコードの作成・検索操作を提供する。
+全 ADMIN 操作の監査証跡記録 (ISO27001) に使用される。
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.audit_log import AuditLog
+
+
+class AuditLogRepository:
+    def __init__(self, db: AsyncSession) -> None:
+        self.db = db
+
+    async def create(
+        self,
+        *,
+        action: str,
+        resource: str,
+        user_id: uuid.UUID | None = None,
+        resource_id: uuid.UUID | None = None,
+        before_data: dict[str, Any] | None = None,
+        after_data: dict[str, Any] | None = None,
+        ip_address: str | None = None,
+        user_agent: str | None = None,
+    ) -> AuditLog:
+        """監査ログを 1 件作成して flush する。
+
+        Args:
+            action:      操作種別 (READ / CREATE / UPDATE / DELETE / LOGIN)
+            resource:    対象リソース名 (notification_deliveries / projects / etc.)
+            user_id:     操作ユーザー ID (None = system / unauthenticated)
+            resource_id: 対象リソースの ID (一覧取得の場合は None)
+            before_data: 変更前データ (READ では None)
+            after_data:  変更後データ / クエリパラメータなどのメタ情報
+            ip_address:  クライアント IP アドレス
+            user_agent:  クライアント User-Agent ヘッダ
+        """
+        log = AuditLog(
+            action=action,
+            resource=resource,
+            user_id=user_id,
+            resource_id=resource_id,
+            before_data=before_data,
+            after_data=after_data,
+            ip_address=ip_address,
+            user_agent=user_agent,
+        )
+        self.db.add(log)
+        await self.db.flush()
+        await self.db.refresh(log)
+        return log

--- a/backend/tests/unit/test_notification_phase2e.py
+++ b/backend/tests/unit/test_notification_phase2e.py
@@ -1,0 +1,88 @@
+"""Phase 2e — audit_logs 統合のユニットテスト
+
+GET /api/v1/notifications/deliveries (ADMIN専用) へのアクセスが
+audit_logs テーブルに正しく記録されることを検証する。
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.repositories.audit_log import AuditLogRepository
+from tests.conftest import ADMIN_USER_ID
+
+# ── AuditLogRepository 単体テスト ─────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_audit_log_create_stores_action_and_resource(db_session_with_users):
+    """create() で action / resource が正しく保存される。"""
+    repo = AuditLogRepository(db_session_with_users)
+
+    log = await repo.create(
+        action="READ",
+        resource="notification_deliveries",
+        user_id=ADMIN_USER_ID,
+    )
+
+    assert log.id is not None
+    assert log.action == "READ"
+    assert log.resource == "notification_deliveries"
+    assert log.user_id == ADMIN_USER_ID
+
+
+@pytest.mark.asyncio
+async def test_audit_log_create_stores_ip_and_user_agent(db_session_with_users):
+    """create() で ip_address / user_agent が記録される。"""
+    repo = AuditLogRepository(db_session_with_users)
+
+    log = await repo.create(
+        action="READ",
+        resource="notification_deliveries",
+        user_id=ADMIN_USER_ID,
+        ip_address="192.0.2.1",
+        user_agent="pytest-client/1.0",
+    )
+
+    assert log.ip_address == "192.0.2.1"
+    assert log.user_agent == "pytest-client/1.0"
+
+
+@pytest.mark.asyncio
+async def test_audit_log_create_stores_after_data_metadata(db_session_with_users):
+    """create() で after_data (クエリパラメータメタ情報) が記録される。"""
+    repo = AuditLogRepository(db_session_with_users)
+    meta = {
+        "page": 1,
+        "per_page": 20,
+        "filter_status": "FAILED",
+        "filter_channel": None,
+        "filter_event_key": None,
+        "filter_user_id": None,
+        "total_returned": 5,
+    }
+
+    log = await repo.create(
+        action="READ",
+        resource="notification_deliveries",
+        user_id=ADMIN_USER_ID,
+        after_data=meta,
+    )
+
+    assert log.after_data["filter_status"] == "FAILED"
+    assert log.after_data["total_returned"] == 5
+    assert log.before_data is None
+
+
+@pytest.mark.asyncio
+async def test_audit_log_create_allows_null_user_id(db_session_with_users):
+    """user_id = None (システム操作) でも create() が成功する。"""
+    repo = AuditLogRepository(db_session_with_users)
+
+    log = await repo.create(
+        action="READ",
+        resource="notification_deliveries",
+    )
+
+    assert log.user_id is None
+    assert log.action == "READ"


### PR DESCRIPTION
## 変更内容

Issue #101 の実装: `GET /api/v1/notifications/deliveries` (ADMIN専用) へのアクセスを既存の `audit_logs` テーブルに記録。

### 追加ファイル
- `backend/app/repositories/audit_log.py` — `AuditLogRepository` 新設
  - `create()`: action / resource / user_id / ip_address / user_agent / after_data を保存
- `backend/tests/unit/test_notification_phase2e.py` — ユニットテスト 4件

### 変更ファイル
- `backend/app/api/v1/routers/notifications.py`
  - `list_notification_deliveries()` に `Request` パラメータ追加
  - レスポンス返却前に `AuditLogRepository.create()` 呼び出し
  - `after_data`: フィルタパラメータ + total_returned (PII除外)
  - `ip_address`: `request.client.host` (None ガード済み)
  - `user_agent`: `request.headers.get("user-agent")`

## テスト結果

```
157 passed, 78 warnings in 64.87s
```

- ruff check: ✅ 全クリア
- mypy: ✅ no issues (Phase 2e ファイル)

## 影響範囲

- `audit_logs` テーブルへの INSERT のみ (SELECT クエリに副作用なし)
- 既存テーブル `0002_audit_logs.py` を利用 (新マイグレーション不要)
- ADMIN 以外のユーザーはエンドポイントアクセス不可のため記録されない

## 残課題

- `retry_transient_failures()` 自動起動設計 (Phase 2f)
  - FastAPI `lifespan` イベントまたは ADMIN trigger エンドポイント

## 関連

- Closes #101
- 関連: #99 (Phase 2d 残スコープ)
- PR #100 (Phase 2d — マージ済み)