### PR TITLE
feat(notifications): Phase 2f — retry 自動起動 + POST /retry エンドポイント

### DIFF
--- a/backend/app/api/v1/routers/notifications.py
+++ b/backend/app/api/v1/routers/notifications.py
@@ -14,6 +14,11 @@ Phase 2d:
 Phase 2e:
     GET /api/v1/notifications/deliveries へのアクセスを audit_logs に記録。
     action='READ', resource='notification_deliveries'
+
+Phase 2f:
+    POST /api/v1/notifications/retry
+        ADMIN が手動で transient 失敗通知の即時リトライを実行する。
+        lifespan バックグラウンドループとは独立した同期実行。
 """
 
 import math
@@ -43,7 +48,7 @@ from app.repositories.notification_preference import (
 from app.schemas.common import ApiResponse, PaginatedResponse, PaginationMeta
 from app.schemas.notification_delivery import NotificationDeliveryResponse
 from app.schemas.notification_preference import NotificationTestResponse
-from app.services.notification_dispatcher import schedule_ping
+from app.services.notification_dispatcher import NotificationDispatcher, schedule_ping
 
 router = APIRouter(
     prefix="/notifications",
@@ -182,6 +187,33 @@ async def list_notification_deliveries(
             per_page=per_page,
             pages=math.ceil(total / per_page) if total > 0 else 0,
         ),
+    )
+
+
+@router.post(
+    "/retry",
+    response_model=ApiResponse[dict],
+    status_code=status.HTTP_200_OK,
+)
+async def post_notification_retry(
+    db: Annotated[AsyncSession, Depends(get_db)],
+    current_user: Annotated[User, Depends(require_roles(UserRole.ADMIN))],
+) -> ApiResponse[dict]:
+    """transient 失敗通知を即時リトライする (ADMIN 専用)。
+
+    lifespan バックグラウンドループ (60 秒間隔) とは独立して同期実行する。
+    最大 3 回リトライ済みの行や permanent 失敗行はスキップされる。
+    """
+    retried = await NotificationDispatcher(db).retry_transient_failures()
+    return ApiResponse(
+        data={
+            "retried_count": len(retried),
+            "message": (
+                f"{len(retried)} 件の transient 失敗通知を再送信しました。"
+                if retried
+                else "リトライ対象の通知がありません。"
+            ),
+        }
     )
 
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2,6 +2,9 @@
 ServiceHub Construction Platform - FastAPI メインアプリケーション
 """
 
+import asyncio
+from contextlib import asynccontextmanager
+
 import structlog
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
@@ -13,6 +16,60 @@ from app.middleware.logging import RequestLoggingMiddleware
 
 logger = structlog.get_logger()
 
+# ── 通知リトライループ (Phase 2f) ──────────────────────
+_RETRY_INTERVAL_SECONDS = 60
+
+
+async def _notification_retry_loop() -> None:  # pragma: no cover
+    """transient 失敗通知を定期的に再送信するバックグラウンドループ。
+
+    60 秒ごとに `retry_transient_failures()` を呼び出し、最大 3 回まで
+    自動リトライする (failure_kind=transient の行のみ対象)。
+
+    複数レプリカ環境では各レプリカが独立実行するが、`mark_retry_pending()` は
+    FAILED 行のみを対象とするため、PENDING に戻った行を並行で 2 度処理しても
+    二重送信は発生しない (Phase 2 同期実装の制約内)。
+    """
+    # Import here to avoid circular imports at module load time
+    from app.services.notification_dispatcher import NotificationDispatcher
+    from app.services.notification_session import notification_session
+
+    while True:
+        await asyncio.sleep(_RETRY_INTERVAL_SECONDS)
+        try:
+            async with notification_session() as db:
+                retried = await NotificationDispatcher(db).retry_transient_failures()
+                if retried:
+                    logger.info(
+                        "notification_retry_loop: retried",
+                        count=len(retried),
+                    )
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:  # pylint: disable=broad-except
+            logger.warning("notification_retry_loop: error", error=str(exc))
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):  # type: ignore[override]
+    """アプリケーション起動/終了ライフサイクル。
+
+    startup: 通知リトライループを asyncio バックグラウンドタスクとして起動。
+    shutdown: タスクをキャンセルして安全に停止する。
+    """
+    retry_task = asyncio.create_task(_notification_retry_loop())
+    logger.info("notification_retry_loop started", interval=_RETRY_INTERVAL_SECONDS)
+    try:
+        yield
+    finally:
+        retry_task.cancel()
+        try:
+            await retry_task
+        except asyncio.CancelledError:
+            pass
+        logger.info("notification_retry_loop stopped")
+
+
 app = FastAPI(
     title=settings.APP_NAME + " API",
     description="建設業向けAI統合業務プラットフォーム",
@@ -20,6 +77,7 @@ app = FastAPI(
     docs_url="/docs",
     redoc_url="/redoc",
     openapi_url="/api/v1/openapi.json",
+    lifespan=lifespan,
 )
 
 # ── ミドルウェア登録 ──────────────────────────────────

--- a/backend/tests/unit/test_notification_phase2f.py
+++ b/backend/tests/unit/test_notification_phase2f.py
@@ -1,0 +1,92 @@
+"""Phase 2f — retry 自動起動 + POST /notifications/retry エンドポイントのユニットテスト
+
+- POST /api/v1/notifications/retry エンドポイントの動作検証 (ADMIN only)
+- リトライ対象あり/なし、permanent 除外の確認
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.repositories.notification_delivery import NotificationDeliveryRepository
+from tests.conftest import ADMIN_USER_ID
+
+# ── ヘルパ ────────────────────────────────────────────────────────
+
+
+async def _make_delivery(
+    db,
+    *,
+    status: str = "PENDING",
+    failure_kind: str | None = None,
+    attempts: int = 0,
+    channel: str = "EMAIL",
+) -> object:
+    repo = NotificationDeliveryRepository(db)
+    d = await repo.create_pending(
+        user_id=ADMIN_USER_ID,
+        event_key="daily_report_submitted",
+        channel=channel,
+        subject="retry test",
+        body_preview="preview",
+    )
+    if status != "PENDING":
+        d.status = status
+    if failure_kind is not None:
+        d.failure_kind = failure_kind
+    d.attempts = attempts
+    await db.flush()
+    await db.refresh(d)
+    return d
+
+
+# ── POST /notifications/retry エンドポイント ──────────────────────
+
+
+@pytest.mark.asyncio
+async def test_retry_endpoint_returns_200_for_admin(auth_client, admin_headers):
+    """ADMIN が POST /notifications/retry を呼ぶと 200 が返る。"""
+    resp = await auth_client.post("/api/v1/notifications/retry", headers=admin_headers)
+    assert resp.status_code == 200
+    data = resp.json()["data"]
+    assert "retried_count" in data
+    assert "message" in data
+
+
+@pytest.mark.asyncio
+async def test_retry_endpoint_forbidden_for_viewer(auth_client, viewer_headers):
+    """VIEWER は POST /notifications/retry で 403 が返る。"""
+    resp = await auth_client.post("/api/v1/notifications/retry", headers=viewer_headers)
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_retry_endpoint_reports_zero_when_no_retryable(
+    auth_client, admin_headers
+):
+    """リトライ対象がない場合は retried_count=0 が返る。"""
+    resp = await auth_client.post("/api/v1/notifications/retry", headers=admin_headers)
+    assert resp.status_code == 200
+    assert resp.json()["data"]["retried_count"] == 0
+
+
+@pytest.mark.asyncio
+async def test_retry_endpoint_skips_permanent_failures(
+    db_session_with_users, auth_client, admin_headers
+):
+    """permanent 失敗行は POST /retry でスキップされる (retried_count=0)。"""
+    await _make_delivery(
+        db_session_with_users, status="FAILED", failure_kind="permanent", attempts=1
+    )
+    await db_session_with_users.commit()
+
+    resp = await auth_client.post("/api/v1/notifications/retry", headers=admin_headers)
+    assert resp.status_code == 200
+    assert resp.json()["data"]["retried_count"] == 0
+
+
+@pytest.mark.asyncio
+async def test_retry_endpoint_unauthenticated_returns_401(auth_client):
+    """認証なしは 401 が返る。"""
+    resp = await auth_client.post("/api/v1/notifications/retry")
+    assert resp.status_code == 401


### PR DESCRIPTION
## 変更内容

### Phase 2f: transient 失敗通知の自動リトライ (Issue #103)

Phase 2d で実装済みの `retry_transient_failures()` に **呼び出し側** を追加する。

#### 実装

| ファイル | 変更内容 |
|---|---|
| `app/main.py` | FastAPI `lifespan` + `asyncio.create_task()` — 60 秒ごとにバックグラウンドリトライ |
| `routers/notifications.py` | `POST /api/v1/notifications/retry` — ADMIN 手動即時リトライ |
| `tests/unit/test_notification_phase2f.py` | 5 件のユニットテスト追加 |

#### バックグラウンドループ仕様

```python
# main.py lifespan startup
retry_task = asyncio.create_task(_notification_retry_loop())

async def _notification_retry_loop():
    while True:
        await asyncio.sleep(60)  # 60 秒間隔
        async with notification_session() as db:
            await NotificationDispatcher(db).retry_transient_failures()
```

#### POST /api/v1/notifications/retry

```
POST /api/v1/notifications/retry
Authorization: Bearer <ADMIN_TOKEN>

200 OK
{
  "data": {
    "retried_count": 3,
    "message": "3 件の transient 失敗通知を再送信しました。"
  }
}
```

## テスト結果

- unit: 162 passed (Phase 2f 5 件追加)
- カバレッジ: 85%
- ruff: All checks passed
- mypy: 既存エラーのみ (Phase 2f 変更ファイルに新規エラーなし)

## 影響範囲

- `main.py` に `lifespan` を追加 → 既存のテストは `TestClient` / `AsyncClient` 経由なので
  lifespan フックは実行されず影響なし
- `POST /notifications/retry` は新規エンドポイント (既存への副作用なし)
- `ADMIN 以外は 403`, 未認証は 401

## 残課題

- k8s 複数レプリカでの重複リトライ抑制 (Phase 3+: Redis 分散ロック)
- lifespan ループの interval を環境変数化 (現在は `_RETRY_INTERVAL_SECONDS = 60` 定数)

## 関連 Issue

Closes #103