### PR TITLE
feat(config): NOTIFICATION_RETRY_INTERVAL_SECONDS 環境変数化 (Phase 2f follow-up)

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -63,6 +63,10 @@ class Settings(BaseSettings):
     SMTP_FROM_ADDRESS: str = "noreply@servicehub.local"
     SMTP_FROM_NAME: str = "ServiceHub"
 
+    # 通知リトライループ設定（Phase 2f）
+    # 本番環境では環境変数 NOTIFICATION_RETRY_INTERVAL_SECONDS で上書き可能。
+    NOTIFICATION_RETRY_INTERVAL_SECONDS: int = 60
+
     model_config = SettingsConfigDict(env_file=".env", extra="ignore")
 
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -17,7 +17,8 @@ from app.middleware.logging import RequestLoggingMiddleware
 logger = structlog.get_logger()
 
 # ── 通知リトライループ (Phase 2f) ──────────────────────
-_RETRY_INTERVAL_SECONDS = 60
+# Configurable via NOTIFICATION_RETRY_INTERVAL_SECONDS env var (default: 60s)
+_RETRY_INTERVAL_SECONDS = settings.NOTIFICATION_RETRY_INTERVAL_SECONDS
 
 
 async def _notification_retry_loop() -> None:  # pragma: no cover

--- a/state.json
+++ b/state.json
@@ -1,9 +1,9 @@
 {
-  "phase": "Phase 2 - 機能強化（Day 8 — 通知Phase2g フロントエンド管理画面 + E2Eテスト）",
-  "loop": "Day8-Build-Phase2g",
-  "loop_count": 76,
+  "phase": "Phase 2 - 機能強化（Day 8 — 通知Phase2g マージ完了 → Phase 2h or lifespan設定化）",
+  "loop": "Day8-Verify-Phase2g-merged",
+  "loop_count": 77,
   "status": "stable",
-  "last_updated": "2026-04-11T21:45:00+09:00",
+  "last_updated": "2026-04-11T20:36:00Z",
   "execution": {
     "start_time": "2026-04-11T17:41:00+09:00",
     "max_duration_minutes": 300,
@@ -46,7 +46,7 @@
   },
   "priorities": {
     "high": [
-      "PR#105 (Phase 2g) merge"
+      "lifespan retry interval 環境変数化 (app/core/config.py に NOTIFICATION_RETRY_INTERVAL_SECONDS 追加)"
     ],
     "medium": [
       "lifespan retry interval 環境変数化",
@@ -93,7 +93,7 @@
       "pr": "#102"
     },
     "phase_2f": {
-      "status": "pr_review",
+      "status": "merged",
       "pr": "#104",
       "features": [
         "FastAPI lifespan + asyncio.create_task() — 60秒ごとバックグラウンドリトライ",
@@ -102,8 +102,8 @@
       ]
     },
     "phase_2g": {
-      "status": "pr_review",
-      "pr": "#105",
+      "status": "merged",
+      "pr": "#106",
       "features": [
         "NotificationDeliveriesPage (ADMIN専用管理画面)",
         "POST /retry ボタン → retried_count 表示",
@@ -121,11 +121,10 @@
       "PR#98",
       "PR#100",
       "PR#102",
-      "PR#104"
+      "PR#104",
+      "PR#106"
     ],
-    "in_review": [
-      "PR#105 (Phase 2g: 通知管理画面 + E2Eテスト)"
-    ],
-    "next": "PR#105 merge後 → Phase 3 or lifespan retry interval 環境変数化"
+    "in_review": [],
+    "next": "lifespan retry interval 環境変数化 → config.py NOTIFICATION_RETRY_INTERVAL_SECONDS"
   }
 }


### PR DESCRIPTION
## 概要

Phase 2f で `backend/app/main.py` にハードコードしていた `_RETRY_INTERVAL_SECONDS = 60` を、pydantic-settings の `Settings` クラス経由で環境変数から読み込めるように変更。

## 変更内容

- `backend/app/core/config.py` — `NOTIFICATION_RETRY_INTERVAL_SECONDS: int = 60` を追加（SMTP 設定ブロックの直後）
- `backend/app/main.py` — `_RETRY_INTERVAL_SECONDS = 60` を `settings.NOTIFICATION_RETRY_INTERVAL_SECONDS` に置換

## 設定方法

`.env` に以下を追加することで間隔を変更できる:

```
NOTIFICATION_RETRY_INTERVAL_SECONDS=300   # 本番: 5分ごと
NOTIFICATION_RETRY_INTERVAL_SECONDS=10    # テスト: 10秒ごと
```

## テスト結果

- `ruff check` / `ruff format --check` → pass
- `python3 -c "from app.core.config import settings; print(settings.NOTIFICATION_RETRY_INTERVAL_SECONDS)"` → `60`（デフォルト正常）

## 影響範囲

バックエンド `config.py` / `main.py` のみ。フロントエンド・DB スキーマへの影響なし。

## 残課題

なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)