### PR TITLE
feat(phase3c): ダークモード対応 — ThemeContext + toggle button + E2E (#112)

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,12 +104,13 @@ graph TB
 | 指標 | 値 |
 | :--- | :--- |
 | 🧪 Backend テスト | **162 件**（pytest / coverage **85%** / 通知 Phase 2 全完了） |
-| 🧪 Frontend テスト | **263 件**（vitest / 41 テストファイル / coverage **88%**） |
-| 🎭 E2E テスト | **170 件**（Playwright / 25 テストファイル / 通知管理画面 +5） |
-| 📊 総テスト数 | **595 件**（Backend + Frontend + E2E） |
+| 🧪 Frontend テスト | **270 件**（vitest / 42 テストファイル / coverage **88%** / Phase 3c ThemeContext +7） |
+| 🎭 E2E テスト | **188 件**（Playwright / 26 テストファイル / Phase 3c dark-mode +5） |
+| 📊 総テスト数 | **620 件**（Backend + Frontend + E2E） |
 | 🖥️ フロントエンドページ | **13 ページ**（通知管理 ADMIN ページ追加） |
 | 🧩 共通 UI コンポーネント | **12 種**（Badge / Button / Card / ErrorBanner / ErrorBoundary / ErrorText / FormField / Modal / Pagination / Skeleton / StatCard / Table） |
 | 🎨 共通 UI 適用率 | **12/12 ページ**（全ページ統一完了） |
+| 🌙 ダークモード | **対応済み**（ThemeContext / localStorage 永続化 / prefers-color-scheme フォールバック / Phase 3c PR#113） |
 | 🔗 API エンドポイント | **53 エンドポイント**（Phase 3a: `/metrics` Prometheus エンドポイント追加） |
 | 🏗️ Repository クラス | **10 クラス**（NotificationDelivery / AuditLog 追加） |
 | 🔧 Service クラス | **13 クラス**（NotificationDispatcher + 関連 Sender 追加） |
@@ -119,7 +120,7 @@ graph TB
 | ✅ CI チェック数 | **15 チェック**（ruff / mypy / pytest / bandit / vitest / build / E2E / dependency / type-check x2 / test-coverage x2 / lint-build x2 + Lighthouse CI） |
 | 📊 Prometheus メトリクス | **有効**（`/metrics` エンドポイント / 全ルート RED メトリクス自動計測） |
 | ⚡ Web Vitals | **有効**（LCP / INP / CLS / TTFB / FCP / web-vitals v5） |
-| 🔒 STABLE 判定 | **達成**（main CI 全 success / Phase 2 通知機能 全 PR merge 済み / Phase 3a PR#110 in review） |
+| 🔒 STABLE 判定 | **達成**（main CI 全 success / Phase 3a PR#110 / Phase 3b PR#111 merge済み / Phase 3c PR#113 in review） |
 
 ### 🏗️ Backend アーキテクチャ
 
@@ -295,7 +296,7 @@ gantt
 | :--- | :--- | :--- | :---: |
 | 🔵 Phase 1 基盤安定化 | 4月 Week 1 | 3層アーキテクチャ100%・E2E基盤・CI安定 | ✅ 完了 |
 | 🟡 Phase 2 機能強化 | 4月〜5月 | UI統一・フォーム改善・E2E拡充・通知機能 Phase2a〜Phase2g 完了 | ✅ 完了 |
-| 🟠 Phase 3 UX改善 | 5月〜6月 | レスポンシブ・アクセシビリティ・パフォーマンス | 🔄 進行中（Phase 3a PR#110） |
+| 🟠 Phase 3 UX改善 | 5月〜6月 | レスポンシブ・アクセシビリティ・パフォーマンス・ダークモード | 🔄 進行中（3a✅ 3b✅ 3c PR#113 in review） |
 | 🔴 Phase 4 高度機能 | 6月〜7月 | リアルタイム通知・AI強化 | ⏳ 予定 |
 | 🟣 Phase 5 リリース準備 | 7月〜9月 | 本番環境・セキュリティ監査・ドキュメント整備 | ⏳ 予定 |
 | 🟢 Phase 6 リリース | 2026-10-03 | **社内公開** 🎉 | ⏳ 予定 |

--- a/frontend/e2e/dark-mode.spec.ts
+++ b/frontend/e2e/dark-mode.spec.ts
@@ -1,0 +1,65 @@
+import { test, expect } from "@playwright/test";
+import { loginAndNavigate } from "./fixtures/api-mocks";
+
+test.describe("Dark Mode — Theme Toggle", () => {
+  test.beforeEach(async ({ page }) => {
+    await loginAndNavigate(page);
+  });
+
+  test("theme toggle button is visible in header", async ({ page }) => {
+    const toggle = page.getByTestId("theme-toggle");
+    await expect(toggle).toBeVisible();
+  });
+
+  test("clicking theme toggle switches to dark mode", async ({ page }) => {
+    // Ensure starting in light mode
+    await page.evaluate(() => localStorage.setItem("theme", "light"));
+    await page.reload();
+
+    const toggle = page.getByTestId("theme-toggle");
+    // Light mode: button label should be "ダークモードに切り替え"
+    await expect(toggle).toHaveAttribute("aria-label", "ダークモードに切り替え");
+
+    await toggle.click();
+
+    // After click: html element should have "dark" class
+    const hasDark = await page.evaluate(() =>
+      document.documentElement.classList.contains("dark"),
+    );
+    expect(hasDark).toBe(true);
+    await expect(toggle).toHaveAttribute("aria-label", "ライトモードに切り替え");
+  });
+
+  test("clicking theme toggle switches from dark back to light", async ({ page }) => {
+    // Start in dark mode
+    await page.evaluate(() => localStorage.setItem("theme", "dark"));
+    await page.reload();
+
+    const toggle = page.getByTestId("theme-toggle");
+    await expect(toggle).toHaveAttribute("aria-label", "ライトモードに切り替え");
+
+    await toggle.click();
+
+    const hasDark = await page.evaluate(() =>
+      document.documentElement.classList.contains("dark"),
+    );
+    expect(hasDark).toBe(false);
+    await expect(toggle).toHaveAttribute("aria-label", "ダークモードに切り替え");
+  });
+
+  test("theme persists across page reload", async ({ page }) => {
+    await page.evaluate(() => localStorage.setItem("theme", "dark"));
+    await page.reload();
+
+    const hasDark = await page.evaluate(() =>
+      document.documentElement.classList.contains("dark"),
+    );
+    expect(hasDark).toBe(true);
+  });
+
+  test("theme toggle button has correct aria-label accessible name", async ({ page }) => {
+    const toggle = page.getByTestId("theme-toggle");
+    const label = await toggle.getAttribute("aria-label");
+    expect(["ダークモードに切り替え", "ライトモードに切り替え"]).toContain(label);
+  });
+});

--- a/frontend/src/__tests__/setup.ts
+++ b/frontend/src/__tests__/setup.ts
@@ -1,5 +1,22 @@
 import "@testing-library/jest-dom/vitest";
 
+// Provide a stub for window.matchMedia which is not implemented in jsdom
+if (typeof window !== "undefined" && !window.matchMedia) {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: (query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    }),
+  });
+}
+
 // Ensure localStorage is available for zustand persist middleware in jsdom
 if (typeof globalThis.localStorage === "undefined" || !globalThis.localStorage.setItem) {
   const store: Record<string, string> = {};

--- a/frontend/src/components/layout/Layout.test.tsx
+++ b/frontend/src/components/layout/Layout.test.tsx
@@ -89,4 +89,22 @@ describe("Layout", () => {
     const menuBtn = buttons.find((b) => b.className.includes("lg:hidden"));
     expect(menuBtn).toBeDefined();
   });
+
+  it("テーマトグルボタンが表示される", () => {
+    renderLayout();
+    const toggle = screen.getByTestId("theme-toggle");
+    expect(toggle).toBeInTheDocument();
+    const label = toggle.getAttribute("aria-label");
+    expect(["ダークモードに切り替え", "ライトモードに切り替え"]).toContain(label);
+  });
+
+  it("テーマトグルをクリックすると aria-label が切り替わる", () => {
+    // Start in light mode
+    localStorage.setItem("theme", "light");
+    renderLayout();
+    const toggle = screen.getByTestId("theme-toggle");
+    expect(toggle).toHaveAttribute("aria-label", "ダークモードに切り替え");
+    fireEvent.click(toggle);
+    expect(toggle).toHaveAttribute("aria-label", "ライトモードに切り替え");
+  });
 });

--- a/frontend/src/components/layout/Layout.test.tsx
+++ b/frontend/src/components/layout/Layout.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen, fireEvent } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { MemoryRouter } from "react-router-dom";
+import { ThemeProvider } from "@/contexts/ThemeContext";
 import Layout from "./Layout";
 
 const mockNavigate = vi.fn();
@@ -23,9 +24,11 @@ vi.mock("@/stores/authStore", () => ({
 
 function renderLayout(path = "/dashboard") {
   return render(
-    <MemoryRouter initialEntries={[path]}>
-      <Layout />
-    </MemoryRouter>,
+    <ThemeProvider>
+      <MemoryRouter initialEntries={[path]}>
+        <Layout />
+      </MemoryRouter>
+    </ThemeProvider>,
   );
 }
 

--- a/frontend/src/components/layout/Layout.tsx
+++ b/frontend/src/components/layout/Layout.tsx
@@ -11,6 +11,8 @@ import {
   Image,
   LogOut,
   Menu,
+  Moon,
+  Sun,
   X,
   Users,
   Settings,
@@ -18,11 +20,13 @@ import {
 } from "lucide-react";
 import { useState } from "react";
 import { useAuthStore } from "@/stores/authStore";
+import { useTheme } from "@/contexts/ThemeContext";
 import clsx from "clsx";
 
 export default function Layout() {
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const { user, logout } = useAuthStore();
+  const { theme, toggleTheme } = useTheme();
   const navigate = useNavigate();
   const location = useLocation();
 
@@ -78,7 +82,7 @@ export default function Layout() {
   };
 
   return (
-    <div className="flex h-screen bg-gray-50">
+    <div className="flex h-screen bg-gray-50 dark:bg-gray-950">
       {/* Mobile overlay */}
       {sidebarOpen && (
         <div
@@ -92,15 +96,15 @@ export default function Layout() {
       <aside
         aria-label="サイドバーナビゲーション"
         className={clsx(
-          "fixed top-0 left-0 h-full w-64 bg-primary-900 text-white z-30 flex flex-col transition-transform duration-200",
+          "fixed top-0 left-0 h-full w-64 bg-primary-900 dark:bg-gray-900 text-white z-30 flex flex-col transition-transform duration-200",
           sidebarOpen ? "translate-x-0" : "-translate-x-full lg:translate-x-0",
         )}
       >
-        <div className="flex items-center gap-2 px-4 h-16 border-b border-primary-700">
+        <div className="flex items-center gap-2 px-4 h-16 border-b border-primary-700 dark:border-gray-700">
           <HardHat className="w-7 h-7 text-construction-orange" aria-hidden="true" />
           <div>
             <p className="text-sm font-bold leading-tight">ServiceHub</p>
-            <p className="text-xs text-primary-300 leading-tight">工事管理</p>
+            <p className="text-xs text-primary-300 dark:text-gray-400 leading-tight">工事管理</p>
           </div>
         </div>
 
@@ -110,14 +114,14 @@ export default function Layout() {
           ))}
         </nav>
 
-        <div className="px-3 py-4 border-t border-primary-700">
-          <div className="px-3 py-2 text-xs text-primary-300 truncate">
+        <div className="px-3 py-4 border-t border-primary-700 dark:border-gray-700">
+          <div className="px-3 py-2 text-xs text-primary-300 dark:text-gray-400 truncate">
             {user?.full_name ?? user?.email}
-            <span className="ml-1 text-primary-400">({user?.role})</span>
+            <span className="ml-1 text-primary-400 dark:text-gray-500">({user?.role})</span>
           </div>
           <button
             onClick={handleLogout}
-            className="flex items-center gap-3 w-full px-3 py-2 rounded-md text-sm text-primary-100 hover:bg-primary-700 hover:text-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white"
+            className="flex items-center gap-3 w-full px-3 py-2 rounded-md text-sm text-primary-100 hover:bg-primary-700 dark:hover:bg-gray-700 hover:text-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white"
           >
             <LogOut className="w-4 h-4" aria-hidden="true" />
             ログアウト
@@ -128,9 +132,9 @@ export default function Layout() {
       {/* Main content */}
       <div className="flex flex-col flex-1 lg:ml-64 min-w-0">
         {/* Header */}
-        <header className="h-16 bg-white border-b border-gray-200 flex items-center px-4 gap-4 flex-shrink-0">
+        <header className="h-16 bg-white dark:bg-gray-900 border-b border-gray-200 dark:border-gray-700 flex items-center px-4 gap-4 flex-shrink-0">
           <button
-            className="lg:hidden p-2 rounded-md text-gray-500 hover:bg-gray-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500"
+            className="lg:hidden p-2 rounded-md text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500"
             onClick={() => setSidebarOpen(!sidebarOpen)}
             aria-label={sidebarOpen ? "メニューを閉じる" : "メニューを開く"}
             aria-expanded={sidebarOpen}
@@ -138,9 +142,22 @@ export default function Layout() {
           >
             {sidebarOpen ? <X className="w-5 h-5" aria-hidden="true" /> : <Menu className="w-5 h-5" aria-hidden="true" />}
           </button>
-          <h1 className="text-lg font-semibold text-gray-800">
+          <h1 className="text-lg font-semibold text-gray-800 dark:text-gray-100 flex-1">
             ServiceHub 工事管理プラットフォーム
           </h1>
+          {/* Theme toggle */}
+          <button
+            onClick={toggleTheme}
+            aria-label={theme === "dark" ? "ライトモードに切り替え" : "ダークモードに切り替え"}
+            data-testid="theme-toggle"
+            className="p-2 rounded-md text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 transition-colors"
+          >
+            {theme === "dark" ? (
+              <Sun className="w-5 h-5" aria-hidden="true" />
+            ) : (
+              <Moon className="w-5 h-5" aria-hidden="true" />
+            )}
+          </button>
         </header>
 
         {/* Page content */}

--- a/frontend/src/components/ui/Badge.tsx
+++ b/frontend/src/components/ui/Badge.tsx
@@ -6,11 +6,11 @@ const badgeVariants = cva(
   {
     variants: {
       variant: {
-        default: "bg-gray-100 text-gray-700",
-        success: "bg-green-100 text-green-800",
-        warning: "bg-yellow-100 text-yellow-800",
-        danger: "bg-red-100 text-red-800",
-        info: "bg-blue-100 text-blue-800",
+        default: "bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300",
+        success: "bg-green-100 dark:bg-green-900/40 text-green-800 dark:text-green-300",
+        warning: "bg-yellow-100 dark:bg-yellow-900/40 text-yellow-800 dark:text-yellow-300",
+        danger: "bg-red-100 dark:bg-red-900/40 text-red-800 dark:text-red-300",
+        info: "bg-blue-100 dark:bg-blue-900/40 text-blue-800 dark:text-blue-300",
       },
       size: {
         sm: "text-xs px-2 py-0.5",

--- a/frontend/src/components/ui/Button.tsx
+++ b/frontend/src/components/ui/Button.tsx
@@ -7,8 +7,8 @@ const buttonVariants = cva(
     variants: {
       variant: {
         primary: "bg-primary-600 text-white hover:bg-primary-700 focus-visible:ring-primary-500",
-        secondary: "bg-white text-gray-700 border border-gray-300 hover:bg-gray-50 focus-visible:ring-gray-400",
-        ghost: "text-gray-700 hover:bg-gray-100 focus-visible:ring-gray-400",
+        secondary: "bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-200 border border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-700 focus-visible:ring-gray-400",
+        ghost: "text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-800 focus-visible:ring-gray-400",
         danger: "bg-red-600 text-white hover:bg-red-700 focus-visible:ring-red-500",
       },
       size: {

--- a/frontend/src/components/ui/Card.tsx
+++ b/frontend/src/components/ui/Card.tsx
@@ -16,7 +16,7 @@ const paddingMap = {
 export function Card({ padding = 'md', className, children, ...rest }: CardProps) {
   return (
     <div
-      className={cn('bg-white rounded-lg shadow', paddingMap[padding], className)}
+      className={cn('bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-900', paddingMap[padding], className)}
       {...rest}
     >
       {children}

--- a/frontend/src/components/ui/FormField.tsx
+++ b/frontend/src/components/ui/FormField.tsx
@@ -19,7 +19,7 @@ export function FormField({
 }: FormFieldProps) {
   return (
     <div className={cn("space-y-1", className)}>
-      <label htmlFor={htmlFor} className="block text-sm font-medium text-gray-700">
+      <label htmlFor={htmlFor} className="block text-sm font-medium text-gray-700 dark:text-gray-300">
         {label}
         {required && <span className="ml-0.5 text-red-500">*</span>}
       </label>
@@ -42,11 +42,12 @@ export function Input({ error, className, ...props }: InputProps) {
     <input
       className={cn(
         "block w-full rounded-md border px-3 py-2 text-sm shadow-sm transition-colors",
+        "bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100",
         "focus:outline-none focus:ring-2 focus:ring-offset-0",
         error
           ? "border-red-300 focus:border-red-500 focus:ring-red-200"
-          : "border-gray-300 focus:border-primary-500 focus:ring-primary-200",
-        "disabled:bg-gray-50 disabled:text-gray-500",
+          : "border-gray-300 dark:border-gray-600 focus:border-primary-500 focus:ring-primary-200",
+        "disabled:bg-gray-50 dark:disabled:bg-gray-700 disabled:text-gray-500 dark:disabled:text-gray-400",
         className,
       )}
       {...props}
@@ -63,11 +64,12 @@ export function Textarea({ error, className, ...props }: TextareaProps) {
     <textarea
       className={cn(
         "block w-full rounded-md border px-3 py-2 text-sm shadow-sm transition-colors",
+        "bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100",
         "focus:outline-none focus:ring-2 focus:ring-offset-0",
         error
           ? "border-red-300 focus:border-red-500 focus:ring-red-200"
-          : "border-gray-300 focus:border-primary-500 focus:ring-primary-200",
-        "disabled:bg-gray-50 disabled:text-gray-500",
+          : "border-gray-300 dark:border-gray-600 focus:border-primary-500 focus:ring-primary-200",
+        "disabled:bg-gray-50 dark:disabled:bg-gray-700 disabled:text-gray-500 dark:disabled:text-gray-400",
         className,
       )}
       {...props}
@@ -86,11 +88,12 @@ export function Select({ error, options, placeholder, className, ...props }: Sel
     <select
       className={cn(
         "block w-full rounded-md border px-3 py-2 text-sm shadow-sm transition-colors",
+        "bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100",
         "focus:outline-none focus:ring-2 focus:ring-offset-0",
         error
           ? "border-red-300 focus:border-red-500 focus:ring-red-200"
-          : "border-gray-300 focus:border-primary-500 focus:ring-primary-200",
-        "disabled:bg-gray-50 disabled:text-gray-500",
+          : "border-gray-300 dark:border-gray-600 focus:border-primary-500 focus:ring-primary-200",
+        "disabled:bg-gray-50 dark:disabled:bg-gray-700 disabled:text-gray-500 dark:disabled:text-gray-400",
         className,
       )}
       {...props}

--- a/frontend/src/components/ui/Modal.tsx
+++ b/frontend/src/components/ui/Modal.tsx
@@ -66,18 +66,18 @@ export function Modal({
     <dialog
       ref={dialogRef}
       className={cn(
-        "w-full rounded-lg bg-white p-0 shadow-xl backdrop:bg-black/40",
+        "w-full rounded-lg bg-white dark:bg-gray-800 p-0 shadow-xl backdrop:bg-black/40",
         sizeMap[size],
         className,
       )}
       onClick={handleBackdrop}
       onCancel={handleCancel}
     >
-      <div className="flex items-center justify-between border-b px-6 py-4">
-        {title && <h2 className="text-lg font-semibold text-gray-900">{title}</h2>}
+      <div className="flex items-center justify-between border-b dark:border-gray-700 px-6 py-4">
+        {title && <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">{title}</h2>}
         <button
           type="button"
-          className="ml-auto rounded-md p-1 text-gray-400 hover:bg-gray-100 hover:text-gray-600"
+          className="ml-auto rounded-md p-1 text-gray-400 dark:text-gray-500 hover:bg-gray-100 dark:hover:bg-gray-700 hover:text-gray-600 dark:hover:text-gray-300"
           onClick={onClose}
           aria-label="閉じる"
         >

--- a/frontend/src/components/ui/Skeleton.tsx
+++ b/frontend/src/components/ui/Skeleton.tsx
@@ -9,7 +9,7 @@ export function Skeleton({ className }: SkeletonProps) {
     <div
       role="status"
       aria-label="読み込み中"
-      className={cn('animate-pulse bg-gray-200 rounded', className)}
+      className={cn('animate-pulse bg-gray-200 dark:bg-gray-700 rounded', className)}
     />
   )
 }

--- a/frontend/src/components/ui/StatCard.tsx
+++ b/frontend/src/components/ui/StatCard.tsx
@@ -31,14 +31,14 @@ export function StatCard({ icon, title, value, trend, colorScheme }: StatCardPro
   const iconColors = colorScheme ? colorSchemeMap[colorScheme] : 'bg-gray-100 text-gray-600'
 
   return (
-    <div className="bg-white rounded-lg shadow p-6">
+    <div className="bg-white dark:bg-gray-800 rounded-lg shadow dark:shadow-gray-900 p-6">
       <div className="flex items-center gap-4">
         <div className={cn('flex h-12 w-12 items-center justify-center rounded-full', iconColors)}>
           {icon}
         </div>
         <div className="flex-1">
-          <p className="text-sm text-gray-500">{title}</p>
-          <p className="text-2xl font-bold text-gray-900">{value}</p>
+          <p className="text-sm text-gray-500 dark:text-gray-400">{title}</p>
+          <p className="text-2xl font-bold text-gray-900 dark:text-gray-100">{value}</p>
         </div>
       </div>
       {trend && (

--- a/frontend/src/contexts/ThemeContext.test.tsx
+++ b/frontend/src/contexts/ThemeContext.test.tsx
@@ -1,0 +1,107 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { ThemeProvider, useTheme } from "./ThemeContext";
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  return <ThemeProvider>{children}</ThemeProvider>;
+}
+
+describe("ThemeContext", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    document.documentElement.classList.remove("dark");
+  });
+
+  it("defaults to light theme when no preference stored", () => {
+    window.matchMedia = (query: string) =>
+      ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: () => {},
+        removeListener: () => {},
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        dispatchEvent: () => false,
+      }) as MediaQueryList;
+
+    const { result } = renderHook(() => useTheme(), { wrapper });
+    expect(result.current.theme).toBe("light");
+    expect(document.documentElement.classList.contains("dark")).toBe(false);
+  });
+
+  it("applies dark class to html element when theme is dark", () => {
+    localStorage.setItem("theme", "dark");
+
+    const { result } = renderHook(() => useTheme(), { wrapper });
+    expect(result.current.theme).toBe("dark");
+    expect(document.documentElement.classList.contains("dark")).toBe(true);
+  });
+
+  it("toggles from light to dark on toggleTheme", () => {
+    localStorage.setItem("theme", "light");
+
+    const { result } = renderHook(() => useTheme(), { wrapper });
+    expect(result.current.theme).toBe("light");
+
+    act(() => {
+      result.current.toggleTheme();
+    });
+
+    expect(result.current.theme).toBe("dark");
+    expect(document.documentElement.classList.contains("dark")).toBe(true);
+    expect(localStorage.getItem("theme")).toBe("dark");
+  });
+
+  it("toggles from dark to light on toggleTheme", () => {
+    localStorage.setItem("theme", "dark");
+
+    const { result } = renderHook(() => useTheme(), { wrapper });
+    expect(result.current.theme).toBe("dark");
+
+    act(() => {
+      result.current.toggleTheme();
+    });
+
+    expect(result.current.theme).toBe("light");
+    expect(document.documentElement.classList.contains("dark")).toBe(false);
+    expect(localStorage.getItem("theme")).toBe("light");
+  });
+
+  it("persists theme to localStorage on toggle", () => {
+    localStorage.setItem("theme", "light");
+
+    const { result } = renderHook(() => useTheme(), { wrapper });
+    act(() => {
+      result.current.toggleTheme();
+    });
+
+    expect(localStorage.getItem("theme")).toBe("dark");
+  });
+
+  it("respects prefers-color-scheme: dark when no stored preference", () => {
+    window.matchMedia = (query: string) =>
+      ({
+        matches: query === "(prefers-color-scheme: dark)",
+        media: query,
+        onchange: null,
+        addListener: () => {},
+        removeListener: () => {},
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        dispatchEvent: () => false,
+      }) as MediaQueryList;
+
+    const { result } = renderHook(() => useTheme(), { wrapper });
+    expect(result.current.theme).toBe("dark");
+  });
+
+  it("throws when useTheme is used outside ThemeProvider", () => {
+    // Suppress React error boundary noise
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    expect(() => renderHook(() => useTheme())).toThrow(
+      "useTheme must be used within ThemeProvider",
+    );
+    spy.mockRestore();
+  });
+});

--- a/frontend/src/contexts/ThemeContext.tsx
+++ b/frontend/src/contexts/ThemeContext.tsx
@@ -42,6 +42,7 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
   );
 }
 
+// eslint-disable-next-line react-refresh/only-export-components
 export function useTheme(): ThemeContextValue {
   const ctx = useContext(ThemeContext);
   if (!ctx) throw new Error("useTheme must be used within ThemeProvider");

--- a/frontend/src/contexts/ThemeContext.tsx
+++ b/frontend/src/contexts/ThemeContext.tsx
@@ -1,0 +1,49 @@
+import { createContext, useContext, useEffect, useState } from "react";
+
+type Theme = "light" | "dark";
+
+interface ThemeContextValue {
+  theme: Theme;
+  toggleTheme: () => void;
+}
+
+const ThemeContext = createContext<ThemeContextValue | null>(null);
+
+const STORAGE_KEY = "theme";
+
+function getInitialTheme(): Theme {
+  const stored = localStorage.getItem(STORAGE_KEY);
+  if (stored === "dark" || stored === "light") return stored;
+  return window.matchMedia("(prefers-color-scheme: dark)").matches
+    ? "dark"
+    : "light";
+}
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const [theme, setTheme] = useState<Theme>(getInitialTheme);
+
+  useEffect(() => {
+    const root = document.documentElement;
+    if (theme === "dark") {
+      root.classList.add("dark");
+    } else {
+      root.classList.remove("dark");
+    }
+    localStorage.setItem(STORAGE_KEY, theme);
+  }, [theme]);
+
+  const toggleTheme = () =>
+    setTheme((t) => (t === "dark" ? "light" : "dark"));
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+
+export function useTheme(): ThemeContextValue {
+  const ctx = useContext(ThemeContext);
+  if (!ctx) throw new Error("useTheme must be used within ThemeProvider");
+  return ctx;
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -5,6 +5,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import App from "./App.tsx";
 import "./index.css";
 import { reportWebVitals } from "./reportWebVitals.ts";
+import { ThemeProvider } from "./contexts/ThemeContext.tsx";
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -17,13 +18,15 @@ const queryClient = new QueryClient({
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
-    <QueryClientProvider client={queryClient}>
-      <BrowserRouter
-          future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
-        >
-        <App />
-      </BrowserRouter>
-    </QueryClientProvider>
+    <ThemeProvider>
+      <QueryClientProvider client={queryClient}>
+        <BrowserRouter
+            future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+          >
+          <App />
+        </BrowserRouter>
+      </QueryClientProvider>
+    </ThemeProvider>
   </React.StrictMode>,
 );
 

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -97,7 +97,7 @@ function QuickActionCard({
       <div className={`p-3 rounded-full ${color}`}>
         <Icon className="w-6 h-6 text-white" />
       </div>
-      <span className="text-sm font-medium text-gray-700">{label}</span>
+      <span className="text-sm font-medium text-gray-700 dark:text-gray-300">{label}</span>
     </Card>
     </Link>
   );
@@ -134,12 +134,12 @@ export default function DashboardPage() {
       {/* Header */}
       <div className="flex items-start justify-between">
         <div>
-          <h2 className="text-2xl font-bold text-gray-900">
+          <h2 className="text-2xl font-bold text-gray-900 dark:text-gray-100">
             こんにちは、{user?.full_name ?? "ユーザー"}さん
           </h2>
-          <p className="text-gray-500 text-sm mt-1">ServiceHub 工事管理プラットフォーム</p>
+          <p className="text-gray-500 dark:text-gray-400 text-sm mt-1">ServiceHub 工事管理プラットフォーム</p>
         </div>
-        <p className="text-sm text-gray-400 mt-1 hidden sm:block">{today}</p>
+        <p className="text-sm text-gray-400 dark:text-gray-500 mt-1 hidden sm:block">{today}</p>
       </div>
 
       {/* Stats Grid */}
@@ -198,7 +198,7 @@ export default function DashboardPage() {
 
       {/* Quick Actions */}
       <div>
-        <h3 className="text-lg font-semibold text-gray-900 mb-3">クイックアクション</h3>
+        <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-3">クイックアクション</h3>
         <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-3">
           <QuickActionCard to="/projects" icon={PlusCircle} label="新規案件作成" color="bg-blue-500" />
           <QuickActionCard to="/reports" icon={ClipboardList} label="日報入力" color="bg-purple-500" />
@@ -213,8 +213,8 @@ export default function DashboardPage() {
         {/* Recent Projects Table */}
         <Card className="lg:col-span-2">
           <div className="flex items-center justify-between mb-4">
-            <h3 className="text-lg font-semibold text-gray-900">最近の工事案件</h3>
-            <Link to="/projects" className="text-sm text-primary-600 hover:text-primary-700">
+            <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100">最近の工事案件</h3>
+            <Link to="/projects" className="text-sm text-primary-600 hover:text-primary-700 dark:text-primary-400">
               すべて表示 →
             </Link>
           </div>
@@ -229,35 +229,35 @@ export default function DashboardPage() {
             <div className="overflow-x-auto">
               <table className="w-full text-sm">
                 <thead>
-                  <tr className="text-left text-xs text-gray-400 border-b border-gray-100">
+                  <tr className="text-left text-xs text-gray-400 dark:text-gray-500 border-b border-gray-100 dark:border-gray-700">
                     <th className="pb-2 font-medium">案件名</th>
                     <th className="pb-2 font-medium hidden sm:table-cell">施主名</th>
                     <th className="pb-2 font-medium">ステータス</th>
                     <th className="pb-2 font-medium hidden md:table-cell">開始日</th>
                   </tr>
                 </thead>
-                <tbody className="divide-y divide-gray-50">
+                <tbody className="divide-y divide-gray-50 dark:divide-gray-700">
                   {recentProjects.data.map((p) => (
                     <tr
                       key={p.id}
-                      className="hover:bg-gray-50 transition-colors"
+                      className="hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors"
                     >
                       <td className="py-3 pr-2">
                         <Link
                           to={`/projects/${p.id}`}
-                          className="font-medium text-gray-900 hover:text-primary-600 block truncate max-w-[160px]"
+                          className="font-medium text-gray-900 dark:text-gray-100 hover:text-primary-600 dark:hover:text-primary-400 block truncate max-w-[160px]"
                         >
                           {p.name}
                         </Link>
-                        <span className="text-xs text-gray-400">{p.project_code}</span>
+                        <span className="text-xs text-gray-400 dark:text-gray-500">{p.project_code}</span>
                       </td>
-                      <td className="py-3 pr-2 hidden sm:table-cell text-gray-600 truncate max-w-[120px]">
+                      <td className="py-3 pr-2 hidden sm:table-cell text-gray-600 dark:text-gray-400 truncate max-w-[120px]">
                         {p.client_name}
                       </td>
                       <td className="py-3 pr-2">
                         <StatusBadge status={p.status} />
                       </td>
-                      <td className="py-3 hidden md:table-cell text-gray-500 whitespace-nowrap">
+                      <td className="py-3 hidden md:table-cell text-gray-500 dark:text-gray-400 whitespace-nowrap">
                         {p.start_date
                           ? new Date(p.start_date).toLocaleDateString("ja-JP")
                           : "—"}
@@ -278,8 +278,8 @@ export default function DashboardPage() {
         {/* Recent Incidents */}
         <Card>
           <div className="flex items-center justify-between mb-4">
-            <h3 className="text-lg font-semibold text-gray-900">最近のインシデント</h3>
-            <Link to="/itsm" className="text-sm text-primary-600 hover:text-primary-700">
+            <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100">最近のインシデント</h3>
+            <Link to="/itsm" className="text-sm text-primary-600 hover:text-primary-700 dark:text-primary-400">
               すべて表示 →
             </Link>
           </div>
@@ -296,10 +296,10 @@ export default function DashboardPage() {
                 <Link
                   key={inc.id}
                   to={`/itsm`}
-                  className="block p-3 rounded-lg border border-gray-100 hover:bg-gray-50 transition-colors"
+                  className="block p-3 rounded-lg border border-gray-100 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors"
                 >
                   <div className="flex items-start justify-between gap-2 mb-1">
-                    <span className="text-xs text-gray-400 font-mono shrink-0">
+                    <span className="text-xs text-gray-400 dark:text-gray-500 font-mono shrink-0">
                       {inc.incident_number}
                     </span>
                     <span
@@ -310,12 +310,12 @@ export default function DashboardPage() {
                       {PRIORITY_LABELS[inc.priority] ?? inc.priority}
                     </span>
                   </div>
-                  <p className="text-sm font-medium text-gray-800 leading-snug line-clamp-2">
+                  <p className="text-sm font-medium text-gray-800 dark:text-gray-200 leading-snug line-clamp-2">
                     {inc.title}
                   </p>
                   <div className="flex items-center justify-between mt-2">
                     <IncidentStatusBadge status={inc.status} />
-                    <span className="text-xs text-gray-400">
+                    <span className="text-xs text-gray-400 dark:text-gray-500">
                       {new Date(inc.created_at).toLocaleDateString("ja-JP")}
                     </span>
                   </div>

--- a/frontend/src/pages/projects/ProjectsPage.tsx
+++ b/frontend/src/pages/projects/ProjectsPage.tsx
@@ -60,7 +60,7 @@ export default function ProjectsPage() {
   return (
     <div className="space-y-6">
       <div className="flex items-center justify-between">
-        <h2 className="text-2xl font-bold text-gray-900">工事案件一覧</h2>
+        <h2 className="text-2xl font-bold text-gray-900 dark:text-gray-100">工事案件一覧</h2>
         <Button leftIcon={<Plus className="w-4 h-4" />} onClick={() => setShowModal(true)}>
           新規案件
         </Button>
@@ -75,7 +75,7 @@ export default function ProjectsPage() {
           value={search}
           onChange={(e) => setSearch(e.target.value)}
           aria-label="工事案件を検索"
-          className="pl-10 pr-4 py-2 w-full border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+          className="pl-10 pr-4 py-2 w-full border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
         />
       </div>
 
@@ -88,19 +88,19 @@ export default function ProjectsPage() {
         <Card padding="none" className="overflow-hidden">
           <div className="overflow-x-auto" role="region" aria-label="工事案件一覧テーブル">
           <table className="min-w-full divide-y divide-gray-200" aria-label="工事案件一覧">
-            <thead className="bg-gray-50">
+            <thead className="bg-gray-50 dark:bg-gray-700">
               <tr>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">案件コード</th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">案件名</th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase hidden md:table-cell">施主</th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase hidden lg:table-cell">期間</th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">ステータス</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">案件コード</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">案件名</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase hidden md:table-cell">施主</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase hidden lg:table-cell">期間</th>
+                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">ステータス</th>
               </tr>
             </thead>
-            <tbody className="divide-y divide-gray-100">
+            <tbody className="divide-y divide-gray-100 dark:divide-gray-700">
               {(filtered ?? []).map((p) => (
-                <tr key={p.id} className="hover:bg-gray-50">
-                  <td className="px-4 py-3 text-sm text-gray-500">{p.project_code}</td>
+                <tr key={p.id} className="hover:bg-gray-50 dark:hover:bg-gray-700/50">
+                  <td className="px-4 py-3 text-sm text-gray-500 dark:text-gray-400">{p.project_code}</td>
                   <td className="px-4 py-3">
                     <Link
                       to={`/projects/${p.id}`}
@@ -109,8 +109,8 @@ export default function ProjectsPage() {
                       {p.name}
                     </Link>
                   </td>
-                  <td className="px-4 py-3 text-sm text-gray-600 hidden md:table-cell">{p.client_name}</td>
-                  <td className="px-4 py-3 text-sm text-gray-500 hidden lg:table-cell">
+                  <td className="px-4 py-3 text-sm text-gray-600 dark:text-gray-400 hidden md:table-cell">{p.client_name}</td>
+                  <td className="px-4 py-3 text-sm text-gray-500 dark:text-gray-400 hidden lg:table-cell">
                     {p.start_date ?? "—"} 〜 {p.end_date ?? "—"}
                   </td>
                   <td className="px-4 py-3">
@@ -134,7 +134,7 @@ export default function ProjectsPage() {
 
           {/* Pagination */}
           {data && (
-            <div className="px-4 py-3 border-t border-gray-200 flex items-center justify-between text-sm text-gray-600">
+            <div className="px-4 py-3 border-t border-gray-200 dark:border-gray-700 flex items-center justify-between text-sm text-gray-600 dark:text-gray-400">
               <span>全 {data.meta.total} 件</span>
               <Pagination
                 page={page}

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,6 +1,7 @@
 /** @type {import('tailwindcss').Config} */
 export default {
   content: ["./index.html", "./src/**/*.{js,ts,jsx,tsx}"],
+  darkMode: "class",
   theme: {
     extend: {
       colors: {

--- a/state.json
+++ b/state.json
@@ -1,9 +1,9 @@
 {
-  "phase": "Phase 3 - UX改善（Day 9 — Phase 3b merged、Phase 3c 計画中）",
-  "loop": "Day9-Phase3b-merged",
-  "loop_count": 80,
-  "status": "stable",
-  "last_updated": "2026-04-11T22:00:00Z",
+  "phase": "Phase 3 - UX改善（Day 9 — Phase 3c dark mode PR#113 in review）",
+  "loop": "Day9-Phase3c-pr-created",
+  "loop_count": 81,
+  "status": "in_review",
+  "last_updated": "2026-04-11T22:30:00Z",
   "execution": {
     "start_time": "2026-04-11T20:50:00+09:00",
     "max_duration_minutes": 300,
@@ -46,7 +46,7 @@
   },
   "priorities": {
     "high": [
-      "Phase 3c 計画 — ダークモード対応 Issue 作成"
+      "PR#113 CI通過後 merge — Phase 3c ダークモード完了"
     ],
     "medium": [
       "他ページ ARIA 属性レビュー (reports, safety, itsm, knowledge 等)",
@@ -63,8 +63,8 @@
     "stability": "stable"
   },
   "metrics": {
-    "unit_tests": 162,
-    "e2e_tests": 183,
+    "unit_tests": 169,
+    "e2e_tests": 188,
     "api_endpoints": 53,
     "backend_coverage": 85,
     "frontend_coverage": 88
@@ -97,9 +97,9 @@
     "phase": "Sprint 4 Phase 3",
     "completed_prs": [
       "PR#92", "PR#93", "PR#95", "PR#96", "PR#98",
-      "PR#100", "PR#102", "PR#104", "PR#106", "PR#107", "PR#110", "PR#111"
+      "PR#100", "PR#102", "PR#104", "PR#106", "PR#107", "PR#110", "PR#111", "PR#113"
     ],
-    "in_review": [],
-    "next": "Phase 3c → ダークモード対応 Issue 作成 → 実装"
+    "in_review": ["PR#113"],
+    "next": "PR#113 CI通過待ち → merge → Phase 3d (他ページ dark: 拡張 or ARIA 拡充)"
   }
 }

--- a/state.json
+++ b/state.json
@@ -1,22 +1,22 @@
 {
-  "phase": "Phase 3 - UX改善（Day 9 — Phase 3c dark mode PR#113 in review）",
-  "loop": "Day9-Phase3c-pr-created",
-  "loop_count": 81,
-  "status": "in_review",
-  "last_updated": "2026-04-11T22:30:00Z",
+  "phase": "Phase 3 - UX改善（Day 9 — Phase 3c dark mode PR#113 CI通過待ち → 安全終了）",
+  "loop": "Day9-Phase3c-safe-shutdown",
+  "loop_count": 82,
+  "status": "safe_shutdown",
+  "last_updated": "2026-04-11T23:10:00Z",
   "execution": {
     "start_time": "2026-04-11T20:50:00+09:00",
     "max_duration_minutes": 300,
-    "elapsed_minutes": 10,
-    "remaining_minutes": 290,
-    "phase": "Build",
+    "elapsed_minutes": 140,
+    "remaining_minutes": 160,
+    "phase": "Shutdown",
     "auto_stop_threshold": 5,
-    "graceful_shutdown": false
+    "graceful_shutdown": true
   },
   "token": {
     "total_budget": 100,
-    "used": 55,
-    "remaining": 45,
+    "used": 70,
+    "remaining": 30,
     "allocation": {
       "monitor": 10,
       "development": 35,
@@ -28,29 +28,33 @@
     },
     "dynamic_mode": true,
     "current_phase_budget": 35,
-    "current_phase_used": 10,
+    "current_phase_used": 20,
     "phase_history": [
       "Monitor:5",
       "Development:35",
-      "Verify:15"
+      "Verify:15",
+      "Monitor:10",
+      "Debug:5"
     ]
   },
   "development_plan": {
     "start_date": "2026-04-03",
     "release_date": "2026-10-03",
-    "current_phase": "Phase 3 UX改善 — Phase 3a パフォーマンス計測基盤",
+    "current_phase": "Phase 3 UX改善 — Phase 3c ダークモード CI修正中",
     "current_sprint": "Sprint 4",
     "total_hours": 416,
-    "hours_used": 50,
+    "hours_used": 52,
     "schedule": "土日 × 8時間"
   },
   "priorities": {
     "high": [
-      "PR#113 CI通過後 merge — Phase 3c ダークモード完了"
+      "PR#113 残りCI (E2E/Lighthouse/Test&Coverage) 通過確認 → merge",
+      "merge後 Issue#112 クローズ、state.json phase_3c: merged に更新"
     ],
     "medium": [
+      "Phase 3d 計画: 他ページ dark: 拡張 (ITSM/Safety/Reports/Knowledge/Users)",
       "他ページ ARIA 属性レビュー (reports, safety, itsm, knowledge 等)",
-      "README.md Phase 3b 完了反映"
+      "README.md Phase 3c 完了反映"
     ],
     "low": [
       "k8s複数レプリカ重複リトライ抑制 (Phase 4+: Redis分散ロック)",
@@ -91,15 +95,49 @@
         "ハンバーガーメニュー aria-expanded/aria-controls/aria-current",
         "モバイルビューポート E2E テスト (375x667) — 13 テスト追加"
       ]
+    },
+    "phase_3c": {
+      "status": "in_review",
+      "pr": "#113",
+      "issue": "#112",
+      "features": [
+        "ThemeContext (localStorage 永続化 / prefers-color-scheme フォールバック)",
+        "Tailwind darkMode: class 設定",
+        "Layout/Card/Button/Badge/Modal/Skeleton/FormField/Dashboard/Projects dark: クラス",
+        "ThemeContext Vitest 7件 / dark-mode E2E 5件",
+        "setup.ts window.matchMedia グローバルスタブ追加"
+      ],
+      "ci_status": {
+        "lint_build": "pass",
+        "test_vitest": "pass",
+        "lint_ruff": "pass",
+        "python_security": "pass",
+        "type_check_mypy": "pass",
+        "dependency_review": "pass",
+        "e2e_playwright": "pending",
+        "lighthouse_audit": "pending",
+        "test_coverage": "pending"
+      }
     }
+  },
+  "resume_point": {
+    "action": "PR#113 CI完了確認 → gh pr merge 113 --squash --delete-branch",
+    "branch": "feat/phase3c-dark-mode",
+    "ci_run_ids": {
+      "frontend": "24282651614",
+      "backend": "24282651606",
+      "security": "24282651601",
+      "lighthouse": "24282651607"
+    },
+    "next_phase": "Phase 3d — 残ページ dark: 拡張 (ITSM/Safety/Reports/Knowledge/Users) or ARIA 拡充"
   },
   "current_sprint": {
     "phase": "Sprint 4 Phase 3",
     "completed_prs": [
       "PR#92", "PR#93", "PR#95", "PR#96", "PR#98",
-      "PR#100", "PR#102", "PR#104", "PR#106", "PR#107", "PR#110", "PR#111", "PR#113"
+      "PR#100", "PR#102", "PR#104", "PR#106", "PR#107", "PR#110", "PR#111"
     ],
     "in_review": ["PR#113"],
-    "next": "PR#113 CI通過待ち → merge → Phase 3d (他ページ dark: 拡張 or ARIA 拡充)"
+    "next": "PR#113 残CI通過 → merge → Phase 3d"
   }
 }


### PR DESCRIPTION
## 変更内容

Issue #112 の実装: WCAG 準拠ダークモード対応

### 新規ファイル
- `frontend/src/contexts/ThemeContext.tsx` — `ThemeProvider` + `useTheme` フック
  - localStorage 永続化
  - `prefers-color-scheme: dark` フォールバック
  - `document.documentElement.classList` 操作による Tailwind dark mode 制御
- `frontend/src/contexts/ThemeContext.test.tsx` — Vitest 7 件
- `frontend/e2e/dark-mode.spec.ts` — Playwright E2E 5 件

### 変更ファイル
- `tailwind.config.js`: `darkMode: "class"` 追加
- `src/main.tsx`: `ThemeProvider` でアプリ全体をラップ
- `Layout.tsx`: ヘッダーにテーマ切り替えボタン（Moon/Sun アイコン・`data-testid="theme-toggle"`・aria-label）
- UI コンポーネント 7 件: `Card / Button / StatCard / Modal / Badge / Skeleton / FormField` に `dark:` Tailwind クラス
- ページ 2 件: `DashboardPage / ProjectsPage` に `dark:` クラス

## テスト結果

| 種別 | 件数 | 内容 |
|------|------|------|
| Vitest (新規) | +7 | ThemeContext: 初期値・切り替え・localStorage・OS設定・Provider外エラー |
| Playwright E2E (新規) | +5 | toggle 表示・light→dark・dark→light・reload 永続化・aria-label |

## 影響範囲

- フロントエンドのみ（バックエンド変更なし）
- 既存 UI は light モードでの外観維持（`dark:` クラスは dark クラス付与時のみ適用）
- アクセシビリティ: `aria-label` でスクリーンリーダー対応

## 残課題

- 他ページ（ITSM / 安全点検 / 写真 / 日報）への `dark:` クラス拡張は Phase 3d 以降

Closes #112

🤖 Generated with [Claude Code](https://claude.com/claude-code)