### PR TITLE
improve(quality): mypy修正 / CI mypy バージョン固定 / redis pytest marker (#116)

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -76,5 +76,5 @@ jobs:
           cache: pip
       - run: |
           cd backend
-          pip install -r requirements.txt mypy
+          pip install -r requirements.txt
           mypy app --ignore-missing-imports

--- a/backend/app/schemas/cost.py
+++ b/backend/app/schemas/cost.py
@@ -12,8 +12,8 @@ class CostRecordCreate(BaseModel):
     record_date: date
     category: str
     description: str
-    budgeted_amount: Decimal = Field(default=0, ge=0)
-    actual_amount: Decimal = Field(default=0, ge=0)
+    budgeted_amount: Decimal = Field(default=Decimal("0"), ge=0)
+    actual_amount: Decimal = Field(default=Decimal("0"), ge=0)
     vendor_name: str | None = None
     invoice_number: str | None = None
     notes: str | None = None

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -18,6 +18,9 @@ testpaths = ["tests"]
 python_files = ["test_*.py"]
 python_functions = ["test_*"]
 addopts = "-v --cov=app --cov-report=term-missing --benchmark-disable"
+markers = [
+    "redis: tests that require a running Redis instance (deselect with -m 'not redis')",
+]
 
 [tool.coverage.run]
 concurrency = ["greenlet", "thread"]

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -115,6 +115,7 @@ async def test_refresh_token_invalid():
 
 
 @pytest.mark.asyncio
+@pytest.mark.redis
 async def test_refresh_with_access_token_fails(auth_client):
     """アクセストークンをリフレッシュに使うと401"""
     # アクセストークン取得
@@ -142,6 +143,7 @@ async def test_me_authenticated(auth_client, admin_headers):
 
 
 @pytest.mark.asyncio
+@pytest.mark.redis
 async def test_logout_success(auth_client):
     """ログアウト - 正常 (refresh_token を body に含めて送信)"""
     # Login to obtain a refresh_token first


### PR DESCRIPTION
## 変更内容

| ファイル | 変更 |
|---|---|
| `backend/app/schemas/cost.py` | `Decimal` フィールドデフォルト `0` → `Decimal("0")` |
| `.github/workflows/ci-backend.yml` | `pip install ... mypy` の末尾 `mypy` を削除 |
| `backend/pyproject.toml` | pytest `redis` マーカーを登録 |
| `backend/tests/test_auth.py` | Redis依存テスト2件に `@pytest.mark.redis` 付与 |

## テスト結果

- `mypy app --ignore-missing-imports`: **0 errors** (修正前: 2 errors)
- `ruff check`: **0 warnings**
- CI: push 後確認

## 影響範囲

- Backend のみ（フロントエンド変更なし）
- ローカル `pytest -m "not redis"` で Redis なし環境でも失敗なし

## 残課題

なし

Closes #116

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Tests**
  * テスト実行の選別機能を追加しました。

* **Chores**
  * CI/CDパイプラインの依存関係管理を最適化しました。
  * データ型の安全性を強化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->