### PR TITLE
feat(phase4a): SSE リアルタイム通知 — /notifications/stream + NotificationBadge

### DIFF
--- a/backend/app/api/v1/deps.py
+++ b/backend/app/api/v1/deps.py
@@ -6,7 +6,7 @@ JWT認証・現在ユーザー取得
 import uuid
 from typing import Annotated
 
-from fastapi import Depends, HTTPException, status
+from fastapi import Depends, HTTPException, Query, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -20,6 +20,7 @@ security = HTTPBearer(auto_error=False)
 async def get_current_user(
     credentials: Annotated[HTTPAuthorizationCredentials | None, Depends(security)],
     db: Annotated[AsyncSession, Depends(get_db)],
+    token_query: Annotated[str | None, Query(alias="token")] = None,
 ):
     """JWTトークン検証→ユーザー取得"""
     from app.models.user import User
@@ -30,10 +31,12 @@ async def get_current_user(
         headers={"WWW-Authenticate": "Bearer"},
     )
 
-    if credentials is None:
+    # Support token via query param for SSE (EventSource cannot set headers)
+    raw_token = credentials.credentials if credentials else token_query
+    if raw_token is None:
         raise credentials_exception
 
-    token_data = verify_token(credentials.credentials)
+    token_data = verify_token(raw_token)
     if token_data is None:
         raise credentials_exception
 

--- a/backend/app/api/v1/routers/notifications.py
+++ b/backend/app/api/v1/routers/notifications.py
@@ -34,6 +34,7 @@ from fastapi import (
     Request,
     status,
 )
+from fastapi.responses import StreamingResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.v1.deps import get_current_user
@@ -49,6 +50,7 @@ from app.schemas.common import ApiResponse, PaginatedResponse, PaginationMeta
 from app.schemas.notification_delivery import NotificationDeliveryResponse
 from app.schemas.notification_preference import NotificationTestResponse
 from app.services.notification_dispatcher import NotificationDispatcher, schedule_ping
+from app.services.sse_manager import sse_manager
 
 router = APIRouter(
     prefix="/notifications",
@@ -214,6 +216,35 @@ async def post_notification_retry(
                 else "リトライ対象の通知がありません。"
             ),
         }
+    )
+
+
+@router.get(
+    "/stream",
+    summary="SSE リアルタイム通知ストリーム (Phase 4a)",
+    response_class=StreamingResponse,
+)
+async def get_notification_stream(
+    current_user: Annotated[User, Depends(get_current_user)],
+) -> StreamingResponse:
+    """認証済みユーザー向け SSE ストリームエンドポイント。
+
+    接続するとサーバーからリアルタイムに通知イベントが push される。
+    クライアントは EventSource API で購読し、切断時は自動再接続する。
+
+    イベントフォーマット:
+        data: {"type": "notification", "id": "...", "title": "...", "message": "..."}
+
+    Keep-alive として 30 秒ごとに `: ping` コメントを送信する。
+    """
+    q = sse_manager.connect(current_user.id)
+    return StreamingResponse(
+        sse_manager.event_stream(current_user.id, q),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "X-Accel-Buffering": "no",  # nginx buffering off
+        },
     )
 
 

--- a/backend/app/services/sse_manager.py
+++ b/backend/app/services/sse_manager.py
@@ -1,0 +1,85 @@
+"""SSE (Server-Sent Events) 接続マネージャ (Phase 4a)
+
+各認証ユーザーに asyncio.Queue を割り当て、通知イベントを push する。
+ConnectionManager はシングルトンとして app.state に保持される。
+"""
+
+import asyncio
+import json
+import logging
+import uuid
+from collections.abc import AsyncGenerator
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Maximum number of buffered events per user before dropping
+_QUEUE_MAX_SIZE = 100
+
+
+class SSEConnectionManager:
+    """ユーザーごとの SSE キューを管理するシングルトン。"""
+
+    def __init__(self) -> None:
+        self._queues: dict[uuid.UUID, list[asyncio.Queue[dict[str, Any] | None]]] = {}
+
+    def connect(self, user_id: uuid.UUID) -> asyncio.Queue[dict[str, Any] | None]:
+        """新しい SSE 接続キューを登録して返す。"""
+        q: asyncio.Queue[dict[str, Any] | None] = asyncio.Queue(maxsize=_QUEUE_MAX_SIZE)
+        self._queues.setdefault(user_id, []).append(q)
+        n = len(self._queues[user_id])
+        logger.debug("SSE connect user=%s total=%d", user_id, n)
+        return q
+
+    def disconnect(
+        self, user_id: uuid.UUID, q: asyncio.Queue[dict[str, Any] | None]
+    ) -> None:
+        """SSE 接続キューを登録解除する。"""
+        queues = self._queues.get(user_id, [])
+        if q in queues:
+            queues.remove(q)
+        if not queues:
+            self._queues.pop(user_id, None)
+        logger.debug("SSE disconnect user=%s", user_id)
+
+    async def push(self, user_id: uuid.UUID, event: dict[str, Any]) -> None:
+        """Push event to all connections for a user; drop oldest if queue is full."""
+        for q in list(self._queues.get(user_id, [])):
+            if q.full():
+                try:
+                    q.get_nowait()  # drop oldest
+                except asyncio.QueueEmpty:
+                    pass
+            await q.put(event)
+
+    async def broadcast(self, event: dict[str, Any]) -> None:
+        """全接続ユーザーにイベントを push する。"""
+        for user_id in list(self._queues.keys()):
+            await self.push(user_id, event)
+
+    async def event_stream(
+        self,
+        user_id: uuid.UUID,
+        q: asyncio.Queue[dict[str, Any] | None],
+    ) -> AsyncGenerator[str, None]:
+        """SSE テキストストリームを生成する。None を受信したら終了。"""
+        # Send initial keep-alive comment
+        yield ": connected\n\n"
+        try:
+            while True:
+                try:
+                    event = await asyncio.wait_for(q.get(), timeout=30.0)
+                except TimeoutError:
+                    # Keep-alive ping
+                    yield ": ping\n\n"
+                    continue
+                if event is None:
+                    break
+                data = json.dumps(event, ensure_ascii=False, default=str)
+                yield f"data: {data}\n\n"
+        finally:
+            self.disconnect(user_id, q)
+
+
+# Module-level singleton — shared across the entire app process
+sse_manager = SSEConnectionManager()

--- a/backend/tests/test_sse.py
+++ b/backend/tests/test_sse.py
@@ -1,0 +1,125 @@
+"""SSE リアルタイム通知テスト (Phase 4a)"""
+
+import asyncio
+import uuid
+
+import pytest
+
+from app.services.sse_manager import SSEConnectionManager  # noqa: E402
+
+# ── Unit tests for SSEConnectionManager ──────────────────────────────────────
+
+
+def test_connect_creates_queue():
+    mgr = SSEConnectionManager()
+    uid = uuid.uuid4()
+    q = mgr.connect(uid)
+    assert q is not None
+    assert uid in mgr._queues
+    mgr.disconnect(uid, q)
+    assert uid not in mgr._queues
+
+
+def test_disconnect_removes_queue():
+    mgr = SSEConnectionManager()
+    uid = uuid.uuid4()
+    q = mgr.connect(uid)
+    mgr.disconnect(uid, q)
+    assert uid not in mgr._queues
+
+
+def test_multiple_connections_same_user():
+    mgr = SSEConnectionManager()
+    uid = uuid.uuid4()
+    q1 = mgr.connect(uid)
+    q2 = mgr.connect(uid)
+    assert len(mgr._queues[uid]) == 2
+    mgr.disconnect(uid, q1)
+    assert len(mgr._queues[uid]) == 1
+    mgr.disconnect(uid, q2)
+    assert uid not in mgr._queues
+
+
+@pytest.mark.asyncio
+async def test_push_delivers_event():
+    mgr = SSEConnectionManager()
+    uid = uuid.uuid4()
+    q = mgr.connect(uid)
+    event = {"type": "notification", "id": "abc", "title": "テスト", "message": "msg"}
+    await mgr.push(uid, event)
+    received = await asyncio.wait_for(q.get(), timeout=1.0)
+    assert received == event
+    mgr.disconnect(uid, q)
+
+
+@pytest.mark.asyncio
+async def test_push_unknown_user_does_nothing():
+    mgr = SSEConnectionManager()
+    uid = uuid.uuid4()
+    # No exception should be raised
+    await mgr.push(uid, {"type": "test"})
+
+
+@pytest.mark.asyncio
+async def test_broadcast_delivers_to_all_users():
+    mgr = SSEConnectionManager()
+    uid1, uid2 = uuid.uuid4(), uuid.uuid4()
+    q1 = mgr.connect(uid1)
+    q2 = mgr.connect(uid2)
+    event = {"type": "broadcast", "message": "hello"}
+    await mgr.broadcast(event)
+    r1 = await asyncio.wait_for(q1.get(), timeout=1.0)
+    r2 = await asyncio.wait_for(q2.get(), timeout=1.0)
+    assert r1 == event
+    assert r2 == event
+    mgr.disconnect(uid1, q1)
+    mgr.disconnect(uid2, q2)
+
+
+@pytest.mark.asyncio
+async def test_event_stream_yields_data():
+    mgr = SSEConnectionManager()
+    uid = uuid.uuid4()
+    q = mgr.connect(uid)
+    event = {"type": "notification", "title": "test"}
+    await mgr.push(uid, event)
+    await q.put(None)  # sentinel to stop stream
+
+    chunks = []
+    async for chunk in mgr.event_stream(uid, q):
+        chunks.append(chunk)
+
+    full = "".join(chunks)
+    assert ": connected" in full
+    assert '"type": "notification"' in full
+
+
+# ── Integration tests for SSE endpoint ───────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_sse_stream_requires_auth(client):
+    """認証なしで SSE ストリームを叩くと 401"""
+    resp = await client.get("/api/v1/notifications/stream")
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_sse_stream_authenticated_content_type(auth_client, admin_headers):
+    """SSE endpoint returns text/event-stream for authenticated user (finite stream mock)"""  # noqa: E501
+    from unittest.mock import patch
+
+    async def finite_stream(self, user_id, q):  # noqa: ANN001
+        yield ": connected\n\n"
+        yield "data: {}\n\n"
+
+    with patch(
+        "app.services.sse_manager.SSEConnectionManager.event_stream",
+        new=finite_stream,
+    ):
+        resp = await auth_client.get(
+            "/api/v1/notifications/stream",
+            headers=admin_headers,
+        )
+    assert resp.status_code == 200
+    assert "text/event-stream" in resp.headers.get("content-type", "")

--- a/frontend/src/__tests__/setup.ts
+++ b/frontend/src/__tests__/setup.ts
@@ -17,6 +17,31 @@ if (typeof window !== "undefined" && !window.matchMedia) {
   });
 }
 
+// EventSource is not implemented in jsdom — provide a no-op stub
+if (typeof window !== "undefined" && !window.EventSource) {
+  class EventSourceStub {
+    static readonly CONNECTING = 0;
+    static readonly OPEN = 1;
+    static readonly CLOSED = 2;
+    readonly CONNECTING = 0;
+    readonly OPEN = 1;
+    readonly CLOSED = 2;
+    readyState = 1;
+    onopen: (() => void) | null = null;
+    onmessage: ((ev: MessageEvent) => void) | null = null;
+    onerror: ((ev: Event) => void) | null = null;
+    constructor(_url: string) {}
+    close() { this.readyState = 2; }
+    addEventListener() {}
+    removeEventListener() {}
+    dispatchEvent() { return false; }
+  }
+  Object.defineProperty(window, "EventSource", {
+    writable: true,
+    value: EventSourceStub,
+  });
+}
+
 // Ensure localStorage is available for zustand persist middleware in jsdom
 if (typeof globalThis.localStorage === "undefined" || !globalThis.localStorage.setItem) {
   const store: Record<string, string> = {};

--- a/frontend/src/components/layout/Layout.test.tsx
+++ b/frontend/src/components/layout/Layout.test.tsx
@@ -4,6 +4,10 @@ import { MemoryRouter } from "react-router-dom";
 import { ThemeProvider } from "@/contexts/ThemeContext";
 import Layout from "./Layout";
 
+vi.mock("@/hooks/useSSE", () => ({
+  useSSE: () => ({ unreadCount: 0, clearUnread: vi.fn(), notifications: [], connected: false }),
+}));
+
 const mockNavigate = vi.fn();
 vi.mock("react-router-dom", async () => {
   const actual = await vi.importActual("react-router-dom");

--- a/frontend/src/components/layout/Layout.tsx
+++ b/frontend/src/components/layout/Layout.tsx
@@ -21,12 +21,15 @@ import {
 import { useState } from "react";
 import { useAuthStore } from "@/stores/authStore";
 import { useTheme } from "@/contexts/ThemeContext";
+import { useSSE } from "@/hooks/useSSE";
+import { NotificationBadge } from "@/components/ui/NotificationBadge";
 import clsx from "clsx";
 
 export default function Layout() {
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const { user, logout } = useAuthStore();
   const { theme, toggleTheme } = useTheme();
+  const { unreadCount, clearUnread, connected } = useSSE();
   const navigate = useNavigate();
   const location = useLocation();
 
@@ -145,6 +148,12 @@ export default function Layout() {
           <h1 className="text-lg font-semibold text-gray-800 dark:text-gray-100 flex-1">
             ServiceHub 工事管理プラットフォーム
           </h1>
+          {/* Notification badge */}
+          <NotificationBadge
+            count={unreadCount}
+            connected={connected}
+            onClick={clearUnread}
+          />
           {/* Theme toggle */}
           <button
             onClick={toggleTheme}

--- a/frontend/src/components/ui/NotificationBadge.test.tsx
+++ b/frontend/src/components/ui/NotificationBadge.test.tsx
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { NotificationBadge } from "./NotificationBadge";
+
+describe("NotificationBadge", () => {
+  it("renders bell icon without badge when count is 0", () => {
+    render(<NotificationBadge count={0} />);
+    expect(screen.getByTestId("notification-badge")).toBeInTheDocument();
+    expect(screen.queryByTestId("unread-count")).toBeNull();
+  });
+
+  it("shows count badge when count > 0", () => {
+    render(<NotificationBadge count={5} />);
+    expect(screen.getByTestId("unread-count")).toHaveTextContent("5");
+  });
+
+  it("shows 99+ when count > 99", () => {
+    render(<NotificationBadge count={150} />);
+    expect(screen.getByTestId("unread-count")).toHaveTextContent("99+");
+  });
+
+  it("calls onClick when clicked", () => {
+    const onClick = vi.fn();
+    render(<NotificationBadge count={3} onClick={onClick} />);
+    fireEvent.click(screen.getByTestId("notification-badge"));
+    expect(onClick).toHaveBeenCalledOnce();
+  });
+
+  it("has accessible aria-label with count", () => {
+    render(<NotificationBadge count={2} />);
+    expect(screen.getByLabelText("未読通知 2 件")).toBeInTheDocument();
+  });
+
+  it("has generic aria-label when count is 0", () => {
+    render(<NotificationBadge count={0} />);
+    expect(screen.getByLabelText("通知")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/ui/NotificationBadge.tsx
+++ b/frontend/src/components/ui/NotificationBadge.tsx
@@ -1,0 +1,35 @@
+import { Bell } from "lucide-react";
+import clsx from "clsx";
+
+interface NotificationBadgeProps {
+  count: number;
+  onClick?: () => void;
+  connected?: boolean;
+}
+
+export function NotificationBadge({ count, onClick, connected = true }: NotificationBadgeProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-label={count > 0 ? `未読通知 ${count} 件` : "通知"}
+      data-testid="notification-badge"
+      className={clsx(
+        "relative p-2 rounded-md transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500",
+        connected
+          ? "text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800"
+          : "text-gray-300 dark:text-gray-600 cursor-default",
+      )}
+    >
+      <Bell className="w-5 h-5" aria-hidden="true" />
+      {count > 0 && (
+        <span
+          data-testid="unread-count"
+          className="absolute top-1 right-1 min-w-[16px] h-4 rounded-full bg-red-500 text-white text-[10px] font-bold flex items-center justify-center px-0.5 leading-none"
+        >
+          {count > 99 ? "99+" : count}
+        </span>
+      )}
+    </button>
+  );
+}

--- a/frontend/src/hooks/useSSE.ts
+++ b/frontend/src/hooks/useSSE.ts
@@ -1,0 +1,101 @@
+/**
+ * SSE (Server-Sent Events) hook for real-time notifications (Phase 4a)
+ *
+ * EventSource does not support custom headers, so the JWT token is passed
+ * as a query parameter. The backend validates it the same way as Authorization header.
+ */
+import { useEffect, useRef, useState } from "react";
+import { useAuthStore } from "@/stores/authStore";
+
+export interface SSENotification {
+  type: string;
+  id: string;
+  title: string;
+  message: string;
+  project_id?: string;
+  created_at?: string;
+}
+
+interface UseSSEOptions {
+  /** Called when a new notification arrives */
+  onNotification?: (notification: SSENotification) => void;
+  /** Auto-reconnect delay in ms (default 3000) */
+  reconnectDelay?: number;
+}
+
+interface UseSSEReturn {
+  /** Unread notification count */
+  unreadCount: number;
+  /** Clear / reset the unread counter */
+  clearUnread: () => void;
+  /** Latest received notifications (up to 50) */
+  notifications: SSENotification[];
+  /** Whether the SSE connection is open */
+  connected: boolean;
+}
+
+const BASE_URL = "/api/v1";
+const MAX_BUFFERED = 50;
+
+export function useSSE(options: UseSSEOptions = {}): UseSSEReturn {
+  const { onNotification, reconnectDelay = 3000 } = options;
+  const token = useAuthStore((s) => s.token);
+  const [unreadCount, setUnreadCount] = useState(0);
+  const [notifications, setNotifications] = useState<SSENotification[]>([]);
+  const [connected, setConnected] = useState(false);
+  const esRef = useRef<EventSource | null>(null);
+  const reconnectTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const clearUnread = () => setUnreadCount(0);
+
+  useEffect(() => {
+    if (!token) return;
+
+    let cancelled = false;
+
+    const connect = () => {
+      if (cancelled) return;
+      const url = `${BASE_URL}/notifications/stream?token=${encodeURIComponent(token)}`;
+      const es = new EventSource(url);
+      esRef.current = es;
+
+      es.onopen = () => {
+        if (!cancelled) setConnected(true);
+      };
+
+      es.onmessage = (ev) => {
+        if (cancelled) return;
+        try {
+          const notification = JSON.parse(ev.data) as SSENotification;
+          setNotifications((prev) => [notification, ...prev].slice(0, MAX_BUFFERED));
+          setUnreadCount((n) => n + 1);
+          onNotification?.(notification);
+        } catch {
+          // ignore malformed events
+        }
+      };
+
+      es.onerror = () => {
+        es.close();
+        setConnected(false);
+        if (!cancelled) {
+          reconnectTimer.current = setTimeout(connect, reconnectDelay);
+        }
+      };
+    };
+
+    connect();
+
+    return () => {
+      cancelled = true;
+      esRef.current?.close();
+      esRef.current = null;
+      if (reconnectTimer.current) {
+        clearTimeout(reconnectTimer.current);
+      }
+      setConnected(false);
+    };
+  }, [token, reconnectDelay, onNotification]);
+
+  return { unreadCount, clearUnread, notifications, connected };
+}


### PR DESCRIPTION
## 変更内容

- **Backend**: `SSEConnectionManager` — `asyncio.Queue` per user、push/broadcast/keep-alive 30s ping
- **Backend**: `GET /api/v1/notifications/stream` — StreamingResponse (text/event-stream)
- **Backend**: `deps.py` に `?token=` クエリパラメータ対応追加（EventSource は Authorization ヘッダー非対応のため）
- **Frontend**: `useSSE.ts` — EventSource wrapper、自動再接続 (3s)、未読カウント管理
- **Frontend**: `NotificationBadge.tsx` — Bell アイコン + 赤バッジ (99+ 表示)
- **Frontend**: `Layout.tsx` ヘッダーに NotificationBadge 統合

## テスト結果

- Backend unit tests: `tests/test_sse.py` 9件 全パス
- Frontend component tests: `NotificationBadge.test.tsx` 6件 全パス
- ruff lint/format: ✅
- mypy: ✅ (90 files, no issues)
- TypeScript: ✅ (no errors)
- ESLint: ✅

## 影響範囲

- `/api/v1/notifications/stream` 新規エンドポイント追加
- `deps.get_current_user` にオプショナルな `?token=` パラメータ追加（既存エンドポイントへの影響なし）
- Layout ヘッダーに NotificationBadge 追加

## 残課題

- `NotificationDispatcher.dispatch()` から `sse_manager.push()` を呼ぶ統合（Phase 4b）
- 通知ドロワー UI（Phase 4b）
- E2E テスト（Phase 4b）

Closes #118

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * リアルタイム通知ストリーミング（SSE）を追加しました
  * トップバーに未読通知数を表示する通知バッジを追加しました（接続状態表示・クリックで未読クリア）
  * トークンをクエリパラメータで送信できるようになりました（ヘッダ未対応クライアント対応）

* **テスト**
  * SSE関連のユニット／統合テストとフロントエンドのコンポーネントテストを追加しました
<!-- end of auto-generated comment: release notes by coderabbit.ai -->