### PR TITLE
feat(phase4b): SSE通知配信連結 + NotificationPanel UI

### DIFF
--- a/backend/app/services/notification_dispatcher.py
+++ b/backend/app/services/notification_dispatcher.py
@@ -1,4 +1,4 @@
-"""通知配信オーケストレータ (Phase 2b)
+"""通知配信オーケストレータ (Phase 2b / Phase 4b)
 
 設計書 §9.2 のアーキテクチャを実装する:
 
@@ -6,6 +6,7 @@
       ├─ 購読ユーザー解決 (notification_preferences 参照)
       ├─ チャンネル別事前書き込み (delivery 行を PENDING で作成)
       ├─ Sender 呼び出し (EmailSender / SlackSender)
+      ├─ SSE push (sse_manager.push — Phase 4b)
       └─ mark_sent / mark_failed で status 更新
 
 === Transaction boundary (Phase 2b 以降) ===
@@ -46,6 +47,7 @@ from app.repositories.notification_preference import NotificationPreferenceRepos
 from app.services.notification_senders import EmailSender, SlackSender
 from app.services.notification_session import notification_session
 from app.services.notification_templates import TemplateRenderer
+from app.services.sse_manager import sse_manager
 
 logger = logging.getLogger(__name__)
 
@@ -109,6 +111,18 @@ class NotificationDispatcher:
                     webhook_url=pref.slack_webhook_url,  # type: ignore[arg-type]
                 )
                 deliveries.append(delivery)
+
+            # SSE push — fire-and-forget to all connected browser tabs (Phase 4b)
+            await sse_manager.push(
+                user.id,
+                {
+                    "type": "notification",
+                    "event_key": event_key,
+                    "title": context.get("title", event_key),
+                    "message": context.get("message", ""),
+                    "timestamp": datetime.now(timezone.utc).isoformat(),
+                },
+            )
 
         return deliveries
 

--- a/backend/tests/unit/test_notification_dispatcher.py
+++ b/backend/tests/unit/test_notification_dispatcher.py
@@ -413,3 +413,80 @@ def test_should_send_slack_returns_true_with_webhook_url():
 
     pref = _FakePref()
     assert NotificationDispatcher._should_send(pref, "evt", "slack") is True
+
+
+# ── SSE push integration (Phase 4b) ──────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_dispatch_pushes_sse_event(db_session_with_users):
+    """dispatch() は購読設定にかかわらず対象ユーザーへ SSE push する。"""
+    from unittest.mock import AsyncMock, patch
+
+    await _set_pref(
+        db_session_with_users,
+        ADMIN_USER_ID,
+        email_enabled=True,
+        event_key="daily_report_submitted",
+        subscribed_to_email=True,
+    )
+    fake_sender = _FakeEmailSender(result=SendResult(ok=True))
+    dispatcher = NotificationDispatcher(
+        db_session_with_users,
+        email_sender=fake_sender,  # type: ignore[arg-type]
+        template_renderer=_FakeRenderer(),  # type: ignore[arg-type]
+    )
+
+    mock_push = AsyncMock()
+    with patch(
+        "app.services.notification_dispatcher.sse_manager.push",
+        new=mock_push,
+    ):
+        await dispatcher.dispatch(
+            event_key="daily_report_submitted",
+            user_ids=[ADMIN_USER_ID],
+            context={"title": "日報提出", "message": "テスト本文"},
+        )
+
+    mock_push.assert_awaited_once()
+    call_args = mock_push.call_args
+    pushed_user_id, event = call_args[0]
+    assert pushed_user_id == ADMIN_USER_ID
+    assert event["type"] == "notification"
+    assert event["event_key"] == "daily_report_submitted"
+    assert event["title"] == "日報提出"
+
+
+@pytest.mark.asyncio
+async def test_dispatch_pushes_sse_even_without_email_subscription(db_session_with_users):
+    """メール購読なしでも SSE push は発生する。"""
+    from unittest.mock import AsyncMock, patch
+
+    await _set_pref(
+        db_session_with_users,
+        PM_USER_ID,
+        email_enabled=False,
+        event_key="project_status_changed",
+        subscribed_to_email=False,
+    )
+    fake_sender = _FakeEmailSender()
+    dispatcher = NotificationDispatcher(
+        db_session_with_users,
+        email_sender=fake_sender,  # type: ignore[arg-type]
+        template_renderer=_FakeRenderer(),  # type: ignore[arg-type]
+    )
+
+    mock_push = AsyncMock()
+    with patch(
+        "app.services.notification_dispatcher.sse_manager.push",
+        new=mock_push,
+    ):
+        await dispatcher.dispatch(
+            event_key="project_status_changed",
+            user_ids=[PM_USER_ID],
+            context={},
+        )
+
+    # Email was not sent but SSE push should still be called
+    assert len(fake_sender.sent) == 0
+    mock_push.assert_awaited_once()

--- a/frontend/src/components/layout/Layout.tsx
+++ b/frontend/src/components/layout/Layout.tsx
@@ -23,15 +23,22 @@ import { useAuthStore } from "@/stores/authStore";
 import { useTheme } from "@/contexts/ThemeContext";
 import { useSSE } from "@/hooks/useSSE";
 import { NotificationBadge } from "@/components/ui/NotificationBadge";
+import { NotificationPanel } from "@/components/ui/NotificationPanel";
 import clsx from "clsx";
 
 export default function Layout() {
   const [sidebarOpen, setSidebarOpen] = useState(false);
+  const [panelOpen, setPanelOpen] = useState(false);
   const { user, logout } = useAuthStore();
   const { theme, toggleTheme } = useTheme();
-  const { unreadCount, clearUnread, connected } = useSSE();
+  const { unreadCount, clearUnread, notifications, connected } = useSSE();
   const navigate = useNavigate();
   const location = useLocation();
+
+  const handleBadgeClick = () => {
+    setPanelOpen((prev) => !prev);
+    clearUnread();
+  };
 
   const navItems = [
     { to: "/dashboard", icon: LayoutDashboard, label: "ダッシュボード" },
@@ -86,6 +93,14 @@ export default function Layout() {
 
   return (
     <div className="flex h-screen bg-gray-50 dark:bg-gray-950">
+      {/* Notification panel */}
+      <NotificationPanel
+        open={panelOpen}
+        notifications={notifications}
+        onClose={() => setPanelOpen(false)}
+        onClearAll={() => { clearUnread(); setPanelOpen(false); }}
+      />
+
       {/* Mobile overlay */}
       {sidebarOpen && (
         <div
@@ -152,7 +167,7 @@ export default function Layout() {
           <NotificationBadge
             count={unreadCount}
             connected={connected}
-            onClick={clearUnread}
+            onClick={handleBadgeClick}
           />
           {/* Theme toggle */}
           <button

--- a/frontend/src/components/ui/NotificationPanel.test.tsx
+++ b/frontend/src/components/ui/NotificationPanel.test.tsx
@@ -1,0 +1,153 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { NotificationPanel } from "./NotificationPanel";
+import type { SSENotification } from "@/hooks/useSSE";
+
+const mockNotifications: SSENotification[] = [
+  {
+    type: "notification",
+    id: "n1",
+    title: "テスト通知1",
+    message: "本文メッセージ1",
+    created_at: "2026-04-18T01:00:00.000Z",
+  },
+  {
+    type: "notification",
+    id: "n2",
+    title: "テスト通知2",
+    message: "本文メッセージ2",
+  },
+];
+
+describe("NotificationPanel", () => {
+  it("open=false のとき何も表示されない", () => {
+    render(
+      <NotificationPanel
+        open={false}
+        notifications={mockNotifications}
+        onClose={vi.fn()}
+        onClearAll={vi.fn()}
+      />,
+    );
+    expect(screen.queryByTestId("notification-panel")).toBeNull();
+  });
+
+  it("open=true のときパネルが表示される", () => {
+    render(
+      <NotificationPanel
+        open={true}
+        notifications={mockNotifications}
+        onClose={vi.fn()}
+        onClearAll={vi.fn()}
+      />,
+    );
+    expect(screen.getByTestId("notification-panel")).toBeInTheDocument();
+  });
+
+  it("通知一覧が表示される", () => {
+    render(
+      <NotificationPanel
+        open={true}
+        notifications={mockNotifications}
+        onClose={vi.fn()}
+        onClearAll={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("テスト通知1")).toBeInTheDocument();
+    expect(screen.getByText("テスト通知2")).toBeInTheDocument();
+    expect(screen.getAllByTestId("notification-item")).toHaveLength(2);
+  });
+
+  it("通知なしのとき空メッセージが表示される", () => {
+    render(
+      <NotificationPanel
+        open={true}
+        notifications={[]}
+        onClose={vi.fn()}
+        onClearAll={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("通知はありません")).toBeInTheDocument();
+  });
+
+  it("閉じるボタンクリックで onClose が呼ばれる", () => {
+    const onClose = vi.fn();
+    render(
+      <NotificationPanel
+        open={true}
+        notifications={[]}
+        onClose={onClose}
+        onClearAll={vi.fn()}
+      />,
+    );
+    fireEvent.click(screen.getByTestId("notification-panel-close"));
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it("すべてクリアボタンクリックで onClearAll が呼ばれる", () => {
+    const onClearAll = vi.fn();
+    render(
+      <NotificationPanel
+        open={true}
+        notifications={mockNotifications}
+        onClose={vi.fn()}
+        onClearAll={onClearAll}
+      />,
+    );
+    fireEvent.click(screen.getByTestId("notification-clear-all"));
+    expect(onClearAll).toHaveBeenCalledOnce();
+  });
+
+  it("Escape キーで onClose が呼ばれる", () => {
+    const onClose = vi.fn();
+    render(
+      <NotificationPanel
+        open={true}
+        notifications={[]}
+        onClose={onClose}
+        onClearAll={vi.fn()}
+      />,
+    );
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it("バックドロップクリックで onClose が呼ばれる", () => {
+    const onClose = vi.fn();
+    render(
+      <NotificationPanel
+        open={true}
+        notifications={[]}
+        onClose={onClose}
+        onClearAll={vi.fn()}
+      />,
+    );
+    fireEvent.mouseDown(screen.getByTestId("notification-panel-backdrop"));
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it("通知なしのとき 'すべてクリア' ボタンが表示されない", () => {
+    render(
+      <NotificationPanel
+        open={true}
+        notifications={[]}
+        onClose={vi.fn()}
+        onClearAll={vi.fn()}
+      />,
+    );
+    expect(screen.queryByTestId("notification-clear-all")).toBeNull();
+  });
+
+  it("role=dialog と aria-modal が設定されている", () => {
+    render(
+      <NotificationPanel
+        open={true}
+        notifications={[]}
+        onClose={vi.fn()}
+        onClearAll={vi.fn()}
+      />,
+    );
+    const panel = screen.getByRole("dialog");
+    expect(panel).toHaveAttribute("aria-modal", "true");
+  });
+});

--- a/frontend/src/components/ui/NotificationPanel.tsx
+++ b/frontend/src/components/ui/NotificationPanel.tsx
@@ -1,0 +1,152 @@
+/**
+ * NotificationPanel — slide-over notification drawer (Phase 4b)
+ *
+ * Rendered inside Layout; opened by clicking the NotificationBadge.
+ * Receives notifications from useSSE and allows clearing them.
+ */
+import { useEffect, useRef } from "react";
+import { X, Bell, CheckCheck } from "lucide-react";
+import type { SSENotification } from "@/hooks/useSSE";
+
+interface NotificationPanelProps {
+  open: boolean;
+  notifications: SSENotification[];
+  onClose: () => void;
+  onClearAll: () => void;
+}
+
+function formatTime(ts: string | undefined): string {
+  if (!ts) return "";
+  try {
+    return new Date(ts).toLocaleString("ja-JP", {
+      month: "2-digit",
+      day: "2-digit",
+      hour: "2-digit",
+      minute: "2-digit",
+    });
+  } catch {
+    return "";
+  }
+}
+
+export function NotificationPanel({
+  open,
+  notifications,
+  onClose,
+  onClearAll,
+}: NotificationPanelProps) {
+  const panelRef = useRef<HTMLDivElement>(null);
+
+  // Close on Escape key
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", handler);
+    return () => document.removeEventListener("keydown", handler);
+  }, [open, onClose]);
+
+  // Close on outside click
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: MouseEvent) => {
+      if (panelRef.current && !panelRef.current.contains(e.target as Node)) {
+        onClose();
+      }
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  return (
+    <>
+      {/* backdrop */}
+      <div
+        className="fixed inset-0 z-40 bg-black/30"
+        aria-hidden="true"
+        data-testid="notification-panel-backdrop"
+      />
+
+      {/* panel */}
+      <div
+        ref={panelRef}
+        role="dialog"
+        aria-modal="true"
+        aria-label="通知パネル"
+        data-testid="notification-panel"
+        className="fixed right-0 top-0 z-50 flex h-full w-80 flex-col bg-white shadow-2xl dark:bg-gray-900"
+      >
+        {/* header */}
+        <div className="flex items-center justify-between border-b border-gray-200 px-4 py-3 dark:border-gray-700">
+          <span className="flex items-center gap-2 font-semibold text-gray-900 dark:text-white">
+            <Bell className="h-4 w-4" aria-hidden="true" />
+            通知
+          </span>
+          <div className="flex items-center gap-1">
+            {notifications.length > 0 && (
+              <button
+                type="button"
+                onClick={onClearAll}
+                className="flex items-center gap-1 rounded px-2 py-1 text-xs text-gray-500 hover:bg-gray-100 dark:text-gray-400 dark:hover:bg-gray-800"
+                aria-label="すべての通知をクリア"
+                data-testid="notification-clear-all"
+              >
+                <CheckCheck className="h-3.5 w-3.5" aria-hidden="true" />
+                すべてクリア
+              </button>
+            )}
+            <button
+              type="button"
+              onClick={onClose}
+              className="rounded p-1 text-gray-500 hover:bg-gray-100 dark:text-gray-400 dark:hover:bg-gray-800"
+              aria-label="通知パネルを閉じる"
+              data-testid="notification-panel-close"
+            >
+              <X className="h-4 w-4" aria-hidden="true" />
+            </button>
+          </div>
+        </div>
+
+        {/* notification list */}
+        <ul
+          className="flex-1 overflow-y-auto divide-y divide-gray-100 dark:divide-gray-800"
+          role="list"
+          aria-label="通知一覧"
+          data-testid="notification-list"
+        >
+          {notifications.length === 0 ? (
+            <li className="flex flex-col items-center justify-center gap-2 py-16 text-gray-400 dark:text-gray-500">
+              <Bell className="h-8 w-8 opacity-30" aria-hidden="true" />
+              <span className="text-sm">通知はありません</span>
+            </li>
+          ) : (
+            notifications.map((n, idx) => (
+              <li
+                key={n.id ?? idx}
+                className="px-4 py-3"
+                data-testid="notification-item"
+              >
+                <p className="text-sm font-medium text-gray-900 dark:text-white">
+                  {n.title}
+                </p>
+                {n.message && (
+                  <p className="mt-0.5 text-xs text-gray-500 dark:text-gray-400 line-clamp-2">
+                    {n.message}
+                  </p>
+                )}
+                {n.created_at && (
+                  <p className="mt-1 text-xs text-gray-400 dark:text-gray-500">
+                    {formatTime(n.created_at)}
+                  </p>
+                )}
+              </li>
+            ))
+          )}
+        </ul>
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
## Phase 4b: SSE 通知配信パイプライン完成

### 変更内容

#### backend
- `NotificationDispatcher.dispatch()` に `sse_manager.push()` 呼び出しを追加
  - Email/Slack 購読設定に関わらず、接続中の全ブラウザタブへ即時 push
  - push イベント形式: `{type, event_key, title, message, timestamp}`
- unit test × 2 追加: `AsyncMock` による `sse_manager.push` モックパターン

#### frontend
- `NotificationPanel` コンポーネント新規作成
  - スライドオーバー通知パネル (z-index 50)
  - Escape キー / パネル外クリックで閉じる
  - 通知一覧 (タイトル・メッセージ・timestamp)
  - 「すべてクリア」ボタン (通知あり時のみ表示)
  - 空状態表示
  - WCAG 2.1 AA 対応 (`role="dialog"`, `aria-modal`, `aria-label`)
- `Layout`: バッジクリック → パネル開閉 + unread クリア連動
- `NotificationPanel.test.tsx` (10 テスト)

### テスト結果
- pytest 23 passed ✅
- TypeScript 型チェック ✅ (エラーなし)
- ruff lint ✅

### 影響範囲
- `NotificationDispatcher.dispatch()` の動作変更 (SSE push 追加)
- 既存の Email/Slack ロジックへの変更なし

### Closes #120

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 通知パネルを追加しました。リアルタイムで通知を受け取り、パネルで確認できます。
  * 通知バッジをクリックして通知パネルを開閉できるようになりました。
  * 「すべてクリア」ボタンで一括して通知をクリアできます。

* **Tests**
  * 通知配信とパネルの機能テストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->