### PR TITLE
chore: Phase 5c post-merge sync — state.json + README coverage 95%

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,10 +105,10 @@ graph TB
 
 | 指標 | 値 |
 | :--- | :--- |
-| 🧪 Backend テスト | **162 件**（pytest / coverage **85%** / 通知 Phase 2 全完了） |
+| 🧪 Backend テスト | **316 件**（pytest / coverage **95%** / Phase 5c AuthService+TemplateRenderer +23 件 / 2 モジュール 100%） |
 | 🧪 Frontend テスト | **270 件**（vitest / 42 テストファイル / coverage **88%** / Phase 3c ThemeContext +7） |
 | 🎭 E2E テスト | **202 件**（Playwright / 27 テストファイル / Phase 4c 通知バッジ・パネル +11 +ダークモード+5） |
-| 📊 総テスト数 | **634 件**（Backend + Frontend + E2E） |
+| 📊 総テスト数 | **788 件**（Backend + Frontend + E2E） |
 | 🖥️ フロントエンドページ | **13 ページ**（通知管理 ADMIN ページ追加） |
 | 🧩 共通 UI コンポーネント | **14 種**（Badge / Button / Card / ErrorBanner / ErrorBoundary / ErrorText / FormField / Modal / NotificationBadge / NotificationPanel / Pagination / Skeleton / StatCard / Table） |
 | 🎨 共通 UI 適用率 | **12/12 ページ**（全ページ統一完了） |
@@ -122,7 +122,7 @@ graph TB
 | ✅ CI チェック数 | **15 チェック**（ruff / mypy / pytest / bandit / vitest / build / E2E / dependency / type-check x2 / test-coverage x2 / lint-build x2 + Lighthouse CI） |
 | 📊 Prometheus メトリクス | **有効**（`/metrics` エンドポイント / 全ルート RED メトリクス自動計測） |
 | ⚡ Web Vitals | **有効**（LCP / INP / CLS / TTFB / FCP / web-vitals v5） |
-| 🔒 STABLE 判定 | **達成**（main CI 全 success / Phase 3a PR#110 / 3b PR#111 / 3c PR#113 / 3d PR#115 / Phase 4a PR#119 / 4b PR#121 / 4c PR#123 全 merge 済み） |
+| 🔒 STABLE 判定 | **達成**（main CI 全 success / Phase 3a PR#110 / 3b PR#111 / 3c PR#113 / 3d PR#115 / Phase 4a PR#119 / 4b PR#121 / 4c PR#123 / Phase 5a PR#129 Docker / Phase 5c PR#130 coverage 95% 全 merge 済み） |
 
 ### 🏗️ Backend アーキテクチャ
 

--- a/state.json
+++ b/state.json
@@ -1,64 +1,48 @@
 {
-  "phase": "Phase 3 - UX改善（Day 9 — Phase 3c merged完了 / Phase 3d 準備完了 → 安全停止）",
-  "loop": "Day9-SafeStop",
-  "loop_count": 84,
-  "status": "stopped",
-  "last_updated": "2026-04-12T01:00:00Z",
+  "phase": "Phase 5c merged (PR #130 a98e179) / Phase 5a Docker merged — 次: Phase 5b Lighthouse or 5d codegen",
+  "loop": "Day18-Phase5c-PostMerge-Sync",
+  "loop_count": 131,
+  "status": "active",
+  "last_updated": "2026-04-18T06:15:00Z",
   "execution": {
-    "start_time": "2026-04-11T20:50:00+09:00",
+    "start_time": "2026-04-18T13:57:32+09:00",
     "max_duration_minutes": 300,
-    "elapsed_minutes": 190,
-    "remaining_minutes": 110,
-    "phase": "SafeStop",
+    "session_deadline": "2026-04-18T18:57:32+09:00",
+    "phase": "Verify + Improvement (並行)",
     "auto_stop_threshold": 5,
     "graceful_shutdown": true
   },
-  "token": {
-    "total_budget": 100,
-    "used": 75,
-    "remaining": 25,
-    "allocation": {
-      "monitor": 10,
-      "development": 35,
-      "verify": 20,
-      "improvement": 10,
-      "debug": 15,
-      "issue_factory": 5,
-      "release": 5
-    },
-    "dynamic_mode": true,
-    "current_phase_budget": 10,
-    "current_phase_used": 5,
-    "phase_history": [
-      "Monitor:5",
-      "Development:35",
-      "Verify:15",
-      "Monitor:10",
-      "Debug:5",
-      "Improvement:5"
-    ]
+  "goal": {
+    "title": "自律開発最適化 — Phase 5 リリース品質"
+  },
+  "kpi": {
+    "success_rate_target": 0.9,
+    "backend_coverage_target": 0.9,
+    "backend_coverage_actual": 0.95,
+    "status": "EXCEEDED"
+  },
+  "automation": {
+    "auto_issue_generation": true,
+    "self_evolution": true
   },
   "development_plan": {
     "start_date": "2026-04-03",
     "release_date": "2026-10-03",
-    "current_phase": "Phase 3 UX改善 — Phase 3d 残ページ dark: 拡張",
-    "current_sprint": "Sprint 4",
-    "total_hours": 416,
-    "hours_used": 54,
+    "current_phase": "Phase 5 — リリース準備 (Docker + Lighthouse + Coverage + Codegen)",
+    "current_sprint": "Sprint 6",
     "schedule": "土日 × 8時間"
   },
   "priorities": {
     "high": [
-      "Phase 3d: 残16ページへの dark: クラス追加 (Issue #114)",
-      "ITSM/Safety/Reports/Knowledge/Users ページ優先対応"
+      "Issue #126 Phase 5b: Lighthouse スコア改善 (LCP/CLS/INP)",
+      "docs/design/ WebUI.html と frontend/src/pages/* の差分分析 (canonical source 化)"
     ],
     "medium": [
-      "他ページ ARIA 属性レビュー (reports, safety, itsm, knowledge 等)",
-      "README.md Phase 3c 完了反映"
+      "Issue #128 Phase 5d: OpenAPI codegen 更新 (Frontend 型同期)"
     ],
     "low": [
-      "k8s複数レプリカ重複リトライ抑制 (Phase 4+: Redis分散ロック)",
-      "i18n 基盤検討"
+      "distroless Docker イメージ検討 (PR #129 follow-up)",
+      "Trivy HIGH 0 検証 (PR #129 follow-up)"
     ]
   },
   "decision_context": {
@@ -67,82 +51,72 @@
     "stability": "stable"
   },
   "metrics": {
-    "unit_tests": 171,
-    "e2e_tests": 193,
+    "backend_tests": 316,
+    "frontend_tests": 270,
+    "e2e_tests": 202,
+    "total_tests": 788,
     "api_endpoints": 53,
-    "backend_coverage": 85,
+    "backend_coverage": 95,
     "frontend_coverage": 88
   },
-  "phase3_status": {
-    "phase_3a": {
+  "phase5_status": {
+    "phase_5a_docker": {
       "status": "merged",
-      "pr": "#110",
-      "issue": "#108",
+      "pr": "#129",
+      "issue": "#125",
+      "merged_at": "2026-04-18T05:00:00Z",
+      "merge_commit": "c4c03c3",
       "features": [
-        "web-vitals v5 (LCP/INP/CLS/TTFB/FCP)",
-        "Prometheus /metrics エンドポイント (prometheus-fastapi-instrumentator)",
-        "Lighthouse CI ワークフロー (staticDistDir モード)",
-        "pytest-benchmark v4 API ベースライン計測",
-        "vite-env.d.ts TypeScript 型定義追加"
-      ]
-    },
-    "phase_3b": {
-      "status": "merged",
-      "pr": "#111",
-      "issue": "#109",
-      "features": [
-        "WCAG 2.1 AA アクセシビリティ対応 (Layout/Projects/Notifications)",
-        "ハンバーガーメニュー aria-expanded/aria-controls/aria-current",
-        "モバイルビューポート E2E テスト (375x667) — 13 テスト追加"
-      ]
-    },
-    "phase_3c": {
-      "status": "merged",
-      "pr": "#113",
-      "issue": "#112",
-      "merged_at": "2026-04-12T00:10:00Z",
-      "features": [
-        "ThemeContext (localStorage 永続化 / prefers-color-scheme フォールバック)",
-        "Tailwind darkMode: class 設定",
-        "Layout/Card/Button/Badge/Modal/Skeleton/FormField/Dashboard/Projects dark: クラス",
-        "ThemeContext Vitest 7件 / dark-mode E2E 5件",
-        "setup.ts window.matchMedia グローバルスタブ追加",
-        "Layout.test.tsx テーマトグル表示・切り替えテスト追加 (2件)"
+        "multi-stage builds (backend 556MB -13% / frontend 48.7MB -9%)",
+        "nginx edge: CSP/X-Frame-Options/Permissions-Policy always",
+        "SSE 専用ロケーション設定",
+        "frontend 内部 nginx: SPA fallback + /assets/ 1y immutable",
+        "nginx.prod.conf 新規 / .dockerignore 新規"
       ],
-      "ci_status": {
-        "lint_build": "pass",
-        "test_vitest": "pass",
-        "lint_ruff": "pass",
-        "python_security": "pass",
-        "type_check_mypy": "pass",
-        "dependency_review": "pass",
-        "e2e_playwright": "pass",
-        "lighthouse_audit": "pass",
-        "test_coverage": "pass"
+      "follow_ups": [
+        "distroless 検討 (サイズ -30% 目標未達)",
+        "Trivy HIGH 0 検証",
+        "実機 compose up 検証"
+      ]
+    },
+    "phase_5b_lighthouse": {
+      "status": "planned",
+      "issue": "#126",
+      "priority": "P2"
+    },
+    "phase_5c_coverage": {
+      "status": "merged",
+      "pr": "#130",
+      "issue": "#127",
+      "merged_at": "2026-04-18T06:06:24Z",
+      "merge_commit": "a98e179",
+      "branch": "feat/phase5c-coverage (deleted)",
+      "achievements": {
+        "coverage_delta": "85% → 95% (+10pp, target 90% 超過)",
+        "tests_added": 23,
+        "modules_100pct": ["app/services/auth_service.py", "app/services/notification_templates/renderer.py"]
       }
     },
-    "phase_3d": {
+    "phase_5d_codegen": {
       "status": "planned",
-      "issue": "#114",
-      "features": [
-        "残16ページへの dark: クラス追加",
-        "ITSMPage / SafetyQualityPage / DailyReportPage / KnowledgePage 等",
-        "全ページ dark: 統一対応"
-      ]
+      "issue": "#128",
+      "priority": "P3"
     }
   },
+  "phase4_status": {
+    "phase_4a_sse": {"status": "merged", "pr": "#119"},
+    "phase_4b_notification_dispatcher": {"status": "merged", "pr": "#121"},
+    "phase_4c_e2e": {"status": "merged", "pr": "#123"}
+  },
   "resume_point": {
-    "action": "Phase 3d 開始: Issue #114 の残16ページ dark: クラス追加",
-    "branch": "feat/phase3d-dark-mode-remaining",
-    "next_phase": "Phase 3d — 残ページ dark: 拡張 (ITSM/Safety/Reports/Knowledge/Users)"
+    "action": "chore PR (post-phase5c sync) merge 後 → docs/design/ 正ソース差分分析 → Phase 5b Lighthouse 着手",
+    "branch": "chore/post-phase5c-state-sync",
+    "next_phase": "Phase 5b Lighthouse または Phase 5d OpenAPI codegen"
   },
   "current_sprint": {
-    "phase": "Sprint 4 Phase 3",
-    "completed_prs": [
-      "PR#92", "PR#93", "PR#95", "PR#96", "PR#98",
-      "PR#100", "PR#102", "PR#104", "PR#106", "PR#107", "PR#110", "PR#111", "PR#113"
-    ],
-    "in_review": [],
-    "next": "Issue #114 Phase 3d 実装 → PR 作成"
+    "phase": "Sprint 6 Phase 5",
+    "completed_prs_phase5": ["PR#129", "PR#130"],
+    "in_review_phase5": [],
+    "next": "Issue #126 (Lighthouse) または #128 (OpenAPI codegen) 着手 / docs/design/ 差分分析"
   }
 }


### PR DESCRIPTION
## Summary
- Phase 5c merge (PR #130 a98e179) 後の state.json 同期と README カバレッジ反映
- README メトリクス表: Backend 162→316 件 / coverage 85%→95% / 総テスト 634→788 件
- STABLE 行に Phase 5a PR#129 / Phase 5c PR#130 追加
- state.json: phase/loop/priorities/resume_point を post-merge へ更新

## 変更内容
### README.md
- \`Backend テスト\` 行: 162 件 → 316 件 / 85% → 95% / Phase 5c +23 件記載
- \`総テスト数\`: 634 件 → 788 件
- \`STABLE 判定\`: Phase 5a PR#129 Docker / Phase 5c PR#130 coverage 95% 追記

### state.json
- \`phase\`: Phase 5c merged 明記、次フェーズ候補記載
- \`phase_5c_coverage\`: status=merged, merged_at, merge_commit=a98e179 記録
- \`priorities.high\`: docs/design/ canonical source 差分分析を追加
- \`resume_point.action\`: chore merge → docs/design/ 差分分析 → Phase 5b 着手
- \`current_sprint.completed_prs_phase5\`: [PR#129, PR#130]

## 影響範囲
- ドキュメントと状態ファイルのみ。実装コードへの影響なし。
- README は外向けの真実として Phase 5c の成果を反映。

## テスト
- \`python3 -c \"import json; json.load(open('state.json'))\"\` → valid
- コード変更なし → 既存 CI (lint/test) は通過見込み

## 残課題
- docs/design/ServiceHub-WebUI.html と frontend/src/pages/* の差分分析 (別タスク)
- Phase 5b Lighthouse (Issue #126) / Phase 5d codegen (Issue #128)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **ドキュメント**
  * テスト実績と品質メトリクスの情報を更新しました。

---

**注記**: このリリースには、エンドユーザーに直接影響する新機能やバグ修正は含まれていません。主に内部の開発追跡とドキュメント管理の更新となります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->