### PR TITLE
feat(phase5e1): 社内グループ 4 ページ新設 (Portal/Notices/HR/Rules) (#132)

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,12 +107,12 @@ graph TB
 | :--- | :--- |
 | 🧪 Backend テスト | **316 件**（pytest / coverage **95%** / Phase 5c AuthService+TemplateRenderer +23 件 / 2 モジュール 100%） |
 | 🧪 Frontend テスト | **270 件**（vitest / 42 テストファイル / coverage **88%** / Phase 3c ThemeContext +7） |
-| 🎭 E2E テスト | **202 件**（Playwright / 27 テストファイル / Phase 4c 通知バッジ・パネル +11 +ダークモード+5） |
-| 📊 総テスト数 | **788 件**（Backend + Frontend + E2E） |
-| 🖥️ フロントエンドページ | **13 ページ**（通知管理 ADMIN ページ追加） |
+| 🎭 E2E テスト | **206 件**（Playwright / 28 テストファイル / Phase 4c 通知バッジ・パネル +11 +ダークモード+5 / Phase 5e-1 社内 4 ページ smoke +4） |
+| 📊 総テスト数 | **792 件**（Backend + Frontend + E2E） |
+| 🖥️ フロントエンドページ | **17 ページ**（Phase 5e-1 社内グループ新設: Portal / Notices / HR / Rules +4） |
 | 🧩 共通 UI コンポーネント | **14 種**（Badge / Button / Card / ErrorBanner / ErrorBoundary / ErrorText / FormField / Modal / NotificationBadge / NotificationPanel / Pagination / Skeleton / StatCard / Table） |
-| 🎨 共通 UI 適用率 | **12/12 ページ**（全ページ統一完了） |
-| 🌙 ダークモード | **全ページ対応完了**（ThemeContext / localStorage 永続化 / prefers-color-scheme フォールバック / Phase 3c PR#113 + Phase 3d PR#115 — 全16ページに dark: クラス適用） |
+| 🎨 共通 UI 適用率 | **12/12 既存ページ**（全ページ統一完了 / Phase 5e-1 新設 4 ページは fixture ベースの reference 実装） |
+| 🌙 ダークモード | **全ページ対応完了**（ThemeContext / localStorage 永続化 / prefers-color-scheme フォールバック / Phase 3c PR#113 + Phase 3d PR#115 + Phase 5e-1 新設 4 ページ — 全17ページに dark: クラス適用） |
 | 🔗 API エンドポイント | **53 エンドポイント**（Phase 3a: `/metrics` Prometheus エンドポイント追加） |
 | 🏗️ Repository クラス | **10 クラス**（NotificationDelivery / AuditLog 追加） |
 | 🔧 Service クラス | **13 クラス**（NotificationDispatcher + 関連 Sender 追加） |
@@ -258,7 +258,8 @@ graph LR
 | `error-boundary.spec.ts` | 5 | ErrorBoundary フォールバックUI・再試行・ナビゲーション |
 | `notification-settings.spec.ts` | 6 | 通知設定 UI (マスタースイッチ・イベント別・保存) |
 | `notification-panel.spec.ts` | 11 | 通知バッジ表示・パネル開閉・SSE 受信・未読カウント・すべてクリア・アクセシビリティ |
-| **合計** | **202** | **全12ページ E2E + CRUD + 認証フロー + AI検索 + エラー境界 + 通知設定 + 通知パネル(Phase 4c)** |
+| `phase5e1-internal-pages.spec.ts` | 4 | 社内ポータル / お知らせ / 人事・勤怠 / 社内規程 — 見出し・セクション・フィルタ smoke (Phase 5e-1) |
+| **合計** | **206** | **全16ページ E2E + CRUD + 認証フロー + AI検索 + エラー境界 + 通知設定 + 通知パネル(Phase 4c) + 社内グループ(Phase 5e-1)** |
 
 ---
 

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -39,7 +39,10 @@
 | CostPage | `frontend/src/pages/cost/CostPage.tsx` |
 | ITSMPage | `frontend/src/pages/itsm/ItsmPage.tsx` |
 | KnowledgePage | `frontend/src/pages/knowledge/KnowledgePage.tsx` |
-| PortalPage (新設) | `frontend/src/pages/portal/` (未実装) |
+| PortalPage (Phase 5e-1) | `frontend/src/pages/internal/PortalPage.tsx` |
+| NoticesPage (Phase 5e-1) | `frontend/src/pages/internal/NoticesPage.tsx` |
+| HRPage (Phase 5e-1) | `frontend/src/pages/internal/HRPage.tsx` |
+| RulesPage (Phase 5e-1) | `frontend/src/pages/internal/RulesPage.tsx` |
 | UsersPage | `frontend/src/pages/users/UsersPage.tsx` |
 | NotifPage | `frontend/src/pages/notifications/NotificationDeliveriesPage.tsx` |
 | SettingsPage | `frontend/src/pages/settings/SettingsPage.tsx` |
@@ -53,3 +56,4 @@
 ## 更新履歴
 
 - v1.0 (2026-04-18): 初版。4グループ構成、社内ポータル新設、ブルー系ブランドカラー統一
+- v1.1 (2026-04-18): Phase 5e-1 実装反映。社内グループ 4 ページ (Portal/Notices/HR/Rules) 実装完了、対応表を 12 → 16 行に拡張

--- a/frontend/e2e/phase5e1-internal-pages.spec.ts
+++ b/frontend/e2e/phase5e1-internal-pages.spec.ts
@@ -41,7 +41,7 @@ test.describe("Phase 5e-1: 社内グループ 4 ページ smoke", () => {
     await expect(page.getByRole("heading", { name: "最近の改訂", level: 2 })).toBeVisible();
 
     await page.getByPlaceholder("規程カテゴリを検索").fill("安全");
-    await expect(page.getByText("安全衛生規程")).toBeVisible();
-    await expect(page.getByText("就業規則")).not.toBeVisible();
+    await expect(page.getByRole("button", { name: /安全衛生規程/ })).toBeVisible();
+    await expect(page.getByRole("button", { name: /^就業規則/ })).not.toBeVisible();
   });
 });

--- a/frontend/e2e/phase5e1-internal-pages.spec.ts
+++ b/frontend/e2e/phase5e1-internal-pages.spec.ts
@@ -1,0 +1,47 @@
+import { test, expect } from "@playwright/test";
+import { loginAndNavigate } from "./fixtures/api-mocks";
+
+test.describe("Phase 5e-1: 社内グループ 4 ページ smoke", () => {
+  test("社内ポータル: 見出しとセクションが表示される", async ({ page }) => {
+    await loginAndNavigate(page);
+    await page.goto("/portal");
+    await expect(page.getByRole("heading", { name: "社内ポータル", level: 1 })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "お知らせ", level: 2 })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "直近のイベント", level: 2 })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "クイックリンク", level: 2 })).toBeVisible();
+  });
+
+  test("お知らせ一覧: カテゴリフィルタで絞り込みできる", async ({ page }) => {
+    await loginAndNavigate(page);
+    await page.goto("/notices");
+    await expect(page.getByRole("heading", { name: "お知らせ", level: 1 })).toBeVisible();
+
+    const importantFilter = page.getByRole("button", { name: "重要" });
+    await importantFilter.click();
+    await expect(importantFilter).toHaveAttribute("aria-pressed", "true");
+    await expect(
+      page.getByText("2026 年度 安全衛生方針の公開について"),
+    ).toBeVisible();
+  });
+
+  test("人事・勤怠: KPI と申請テーブルが表示される", async ({ page }) => {
+    await loginAndNavigate(page);
+    await page.goto("/hr");
+    await expect(page.getByRole("heading", { name: "人事・勤怠", level: 1 })).toBeVisible();
+    await expect(page.getByText("今月稼働日")).toBeVisible();
+    await expect(page.getByText("有給残")).toBeVisible();
+    await expect(page.getByRole("heading", { name: "手続きメニュー", level: 2 })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "最近の申請", level: 2 })).toBeVisible();
+  });
+
+  test("社内規程: カテゴリ検索で絞り込みできる", async ({ page }) => {
+    await loginAndNavigate(page);
+    await page.goto("/rules");
+    await expect(page.getByRole("heading", { name: "社内規程", level: 1 })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "最近の改訂", level: 2 })).toBeVisible();
+
+    await page.getByPlaceholder("規程カテゴリを検索").fill("安全");
+    await expect(page.getByText("安全衛生規程")).toBeVisible();
+    await expect(page.getByText("就業規則")).not.toBeVisible();
+  });
+});

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -13,6 +13,10 @@ import PhotosPage from "@/pages/photos/PhotosPage";
 import UsersPage from "@/pages/users/UsersPage";
 import SettingsPage from "@/pages/settings/SettingsPage";
 import NotificationDeliveriesPage from "@/pages/notifications/NotificationDeliveriesPage";
+import PortalPage from "@/pages/internal/PortalPage";
+import NoticesPage from "@/pages/internal/NoticesPage";
+import HRPage from "@/pages/internal/HRPage";
+import RulesPage from "@/pages/internal/RulesPage";
 import { useAuthStore } from "@/stores/authStore";
 
 function PrivateRoute({ children }: { children: React.ReactNode }) {
@@ -47,6 +51,10 @@ export default function App() {
           path="admin/notifications"
           element={<NotificationDeliveriesPage />}
         />
+        <Route path="portal" element={<PortalPage />} />
+        <Route path="notices" element={<NoticesPage />} />
+        <Route path="hr" element={<HRPage />} />
+        <Route path="rules" element={<RulesPage />} />
         <Route path="settings" element={<SettingsPage />} />
       </Route>
     </Routes>

--- a/frontend/src/components/layout/Layout.tsx
+++ b/frontend/src/components/layout/Layout.tsx
@@ -17,6 +17,10 @@ import {
   Users,
   Settings,
   Bell,
+  Home,
+  Newspaper,
+  UserCog,
+  BookText,
 } from "lucide-react";
 import { useState } from "react";
 import { useAuthStore } from "@/stores/authStore";
@@ -49,6 +53,10 @@ export default function Layout() {
     { to: "/photos", icon: Image, label: "写真管理" },
     { to: "/itsm", icon: AlertCircle, label: "ITSM" },
     { to: "/knowledge", icon: BookOpen, label: "ナレッジ" },
+    { to: "/portal", icon: Home, label: "社内ポータル" },
+    { to: "/notices", icon: Newspaper, label: "お知らせ" },
+    { to: "/hr", icon: UserCog, label: "人事・勤怠" },
+    { to: "/rules", icon: BookText, label: "社内規程" },
     ...(user?.role === "ADMIN"
       ? [
           { to: "/users", icon: Users, label: "ユーザー管理" },

--- a/frontend/src/pages/internal/HRPage.tsx
+++ b/frontend/src/pages/internal/HRPage.tsx
@@ -1,0 +1,112 @@
+import { ChevronRight } from "lucide-react";
+import { hrKpis, hrMenus, applications } from "./_fixtures";
+
+const kpiTone: Record<NonNullable<(typeof hrKpis)[number]["tone"]>, string> = {
+  ok: "text-emerald-600 dark:text-emerald-400",
+  warn: "text-amber-600 dark:text-amber-400",
+  err: "text-red-600 dark:text-red-400",
+};
+
+const statusTone: Record<(typeof applications)[number]["tone"], string> = {
+  ok: "bg-emerald-50 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-300",
+  warn: "bg-amber-50 text-amber-700 dark:bg-amber-900/30 dark:text-amber-300",
+  err: "bg-red-50 text-red-700 dark:bg-red-900/30 dark:text-red-300",
+};
+
+export default function HRPage() {
+  return (
+    <div className="space-y-6">
+      <header className="space-y-2">
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-white">人事・勤怠</h1>
+        <p className="text-sm text-gray-600 dark:text-gray-400">
+          勤怠・申請・給与・シフトなど人事関連の手続きを行えます。
+        </p>
+      </header>
+
+      <section aria-label="人事 KPI" className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        {hrKpis.map((k) => (
+          <div
+            key={k.label}
+            className="rounded-xl border border-gray-200 bg-white p-4 shadow-sm dark:border-gray-700 dark:bg-gray-900"
+          >
+            <p className="text-xs font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">
+              {k.label}
+            </p>
+            <p
+              className={
+                "mt-2 text-2xl font-bold tabular-nums " +
+                (k.tone ? kpiTone[k.tone] : "text-gray-900 dark:text-white")
+              }
+            >
+              {k.value}
+            </p>
+            <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">{k.sub}</p>
+          </div>
+        ))}
+      </section>
+
+      <section
+        aria-label="手続きメニュー"
+        className="rounded-xl border border-gray-200 bg-white p-5 shadow-sm dark:border-gray-700 dark:bg-gray-900"
+      >
+        <h2 className="mb-4 text-lg font-semibold text-gray-900 dark:text-white">手続きメニュー</h2>
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          {hrMenus.map(({ icon: Icon, label, desc }) => (
+            <button
+              key={label}
+              type="button"
+              className="flex items-start gap-3 rounded-lg border border-gray-200 p-4 text-left transition-colors hover:border-primary-300 hover:bg-primary-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 dark:border-gray-700 dark:hover:border-primary-600 dark:hover:bg-primary-900/20"
+            >
+              <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-primary-50 text-primary-600 dark:bg-primary-900/40 dark:text-primary-300">
+                <Icon className="h-5 w-5" aria-hidden="true" />
+              </span>
+              <span className="min-w-0 flex-1">
+                <span className="block text-sm font-semibold text-gray-900 dark:text-white">{label}</span>
+                <span className="mt-0.5 block text-xs text-gray-500 dark:text-gray-400">{desc}</span>
+              </span>
+              <ChevronRight className="mt-1 h-4 w-4 shrink-0 text-gray-400" aria-hidden="true" />
+            </button>
+          ))}
+        </div>
+      </section>
+
+      <section
+        aria-label="最近の申請"
+        className="rounded-xl border border-gray-200 bg-white shadow-sm dark:border-gray-700 dark:bg-gray-900"
+      >
+        <header className="flex items-center justify-between border-b border-gray-200 px-5 py-3 dark:border-gray-700">
+          <h2 className="text-lg font-semibold text-gray-900 dark:text-white">最近の申請</h2>
+          <span className="text-xs text-gray-500 dark:text-gray-400">直近 4 件</span>
+        </header>
+        <div className="overflow-x-auto">
+          <table className="min-w-full divide-y divide-gray-200 text-sm dark:divide-gray-700">
+            <thead className="bg-gray-50 text-xs uppercase tracking-wide text-gray-500 dark:bg-gray-800 dark:text-gray-400">
+              <tr>
+                <th scope="col" className="px-4 py-2 text-left font-medium">種別</th>
+                <th scope="col" className="px-4 py-2 text-left font-medium">期間</th>
+                <th scope="col" className="px-4 py-2 text-left font-medium">申請日</th>
+                <th scope="col" className="px-4 py-2 text-left font-medium">承認者</th>
+                <th scope="col" className="px-4 py-2 text-left font-medium">状態</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-200 dark:divide-gray-700">
+              {applications.map((a) => (
+                <tr key={`${a.kind}-${a.appliedAt}`} className="hover:bg-gray-50 dark:hover:bg-gray-800/60">
+                  <td className="px-4 py-3 font-medium text-gray-900 dark:text-white">{a.kind}</td>
+                  <td className="px-4 py-3 text-gray-700 tabular-nums dark:text-gray-300">{a.period}</td>
+                  <td className="px-4 py-3 text-gray-500 tabular-nums dark:text-gray-400">{a.appliedAt}</td>
+                  <td className="px-4 py-3 text-gray-700 dark:text-gray-300">{a.approver}</td>
+                  <td className="px-4 py-3">
+                    <span className={`inline-flex rounded-full px-2 py-0.5 text-xs font-medium ${statusTone[a.tone]}`}>
+                      {a.status}
+                    </span>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/pages/internal/NoticesPage.tsx
+++ b/frontend/src/pages/internal/NoticesPage.tsx
@@ -1,0 +1,122 @@
+import { useMemo, useState } from "react";
+import { Pin, Search } from "lucide-react";
+import { notices, type NoticeCategory } from "./_fixtures";
+
+const categoryTone: Record<NoticeCategory, string> = {
+  重要: "bg-red-50 text-red-700 dark:bg-red-900/30 dark:text-red-300",
+  人事: "bg-blue-50 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300",
+  ITSM: "bg-purple-50 text-purple-700 dark:bg-purple-900/30 dark:text-purple-300",
+  福利厚生: "bg-emerald-50 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-300",
+  規程: "bg-amber-50 text-amber-700 dark:bg-amber-900/30 dark:text-amber-300",
+  安全: "bg-orange-50 text-orange-700 dark:bg-orange-900/30 dark:text-orange-300",
+};
+
+const filters: ("すべて" | NoticeCategory)[] = [
+  "すべて",
+  "重要",
+  "人事",
+  "ITSM",
+  "福利厚生",
+  "規程",
+  "安全",
+];
+
+export default function NoticesPage() {
+  const [active, setActive] = useState<(typeof filters)[number]>("すべて");
+  const [query, setQuery] = useState("");
+
+  const filtered = useMemo(() => {
+    return notices.filter((n) => {
+      const matchesCategory = active === "すべて" || n.cat === active;
+      const matchesQuery = query.trim() === "" || n.title.includes(query.trim());
+      return matchesCategory && matchesQuery;
+    });
+  }, [active, query]);
+
+  return (
+    <div className="space-y-6">
+      <header className="space-y-2">
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-white">お知らせ</h1>
+        <p className="text-sm text-gray-600 dark:text-gray-400">
+          社内全体向けの通知・告知を閲覧できます。重要なお知らせはピン留めされます。
+        </p>
+      </header>
+
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex flex-wrap gap-2">
+          {filters.map((f) => {
+            const selected = f === active;
+            return (
+              <button
+                key={f}
+                type="button"
+                onClick={() => setActive(f)}
+                className={
+                  "rounded-full px-3.5 py-1.5 text-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 " +
+                  (selected
+                    ? "bg-primary-600 text-white dark:bg-primary-500"
+                    : "bg-gray-100 text-gray-700 hover:bg-gray-200 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700")
+                }
+                aria-pressed={selected}
+              >
+                {f}
+              </button>
+            );
+          })}
+        </div>
+
+        <label className="relative flex w-full items-center sm:w-72">
+          <Search className="pointer-events-none absolute left-3 h-4 w-4 text-gray-400" aria-hidden="true" />
+          <input
+            type="search"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="タイトルで検索"
+            className="w-full rounded-md border border-gray-300 bg-white py-2 pl-9 pr-3 text-sm text-gray-900 placeholder:text-gray-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 dark:border-gray-700 dark:bg-gray-900 dark:text-white"
+          />
+        </label>
+      </div>
+
+      <ul className="divide-y divide-gray-200 rounded-xl border border-gray-200 bg-white dark:divide-gray-700 dark:border-gray-700 dark:bg-gray-900">
+        {filtered.length === 0 ? (
+          <li className="px-4 py-8 text-center text-sm text-gray-500 dark:text-gray-400">
+            条件に一致するお知らせはありません
+          </li>
+        ) : (
+          filtered.map((n) => (
+            <li
+              key={n.id}
+              className={
+                "flex flex-col gap-1 px-4 py-3 sm:flex-row sm:items-center sm:justify-between " +
+                (n.pinned ? "bg-amber-50/60 dark:bg-amber-900/10" : "")
+              }
+            >
+              <div className="flex min-w-0 items-start gap-3">
+                {n.pinned ? (
+                  <Pin className="mt-0.5 h-4 w-4 shrink-0 text-amber-500" aria-label="ピン留め" />
+                ) : (
+                  <span className="h-4 w-4 shrink-0" aria-hidden="true" />
+                )}
+                <div className="min-w-0">
+                  <p className="truncate text-sm font-medium text-gray-900 dark:text-white">{n.title}</p>
+                  <div className="mt-1 flex flex-wrap items-center gap-2 text-xs text-gray-500 dark:text-gray-400">
+                    <span className={`inline-flex rounded-full px-2 py-0.5 font-medium ${categoryTone[n.cat]}`}>
+                      {n.cat}
+                    </span>
+                    <span>{n.by}</span>
+                    <time>{n.date}</time>
+                  </div>
+                </div>
+              </div>
+              {n.readCount ? (
+                <span className="shrink-0 text-xs text-gray-500 tabular-nums dark:text-gray-400">
+                  既読 {n.readCount[0]} / {n.readCount[1]}
+                </span>
+              ) : null}
+            </li>
+          ))
+        )}
+      </ul>
+    </div>
+  );
+}

--- a/frontend/src/pages/internal/PortalPage.tsx
+++ b/frontend/src/pages/internal/PortalPage.tsx
@@ -1,0 +1,170 @@
+import { Link } from "react-router-dom";
+import { Bell, Calendar, ChevronRight, PartyPopper, Sparkles } from "lucide-react";
+import {
+  notices,
+  events,
+  quickLinks,
+  birthdays,
+  newHires,
+} from "./_fixtures";
+
+const categoryTone: Record<string, string> = {
+  重要: "bg-red-50 text-red-700 dark:bg-red-900/30 dark:text-red-300",
+  人事: "bg-blue-50 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300",
+  ITSM: "bg-purple-50 text-purple-700 dark:bg-purple-900/30 dark:text-purple-300",
+  福利厚生: "bg-emerald-50 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-300",
+  規程: "bg-amber-50 text-amber-700 dark:bg-amber-900/30 dark:text-amber-300",
+  安全: "bg-orange-50 text-orange-700 dark:bg-orange-900/30 dark:text-orange-300",
+};
+
+const eventTone: Record<string, string> = {
+  brand: "bg-primary-50 text-primary-700 dark:bg-primary-900/30 dark:text-primary-200",
+  safety: "bg-orange-50 text-orange-700 dark:bg-orange-900/30 dark:text-orange-200",
+  warn: "bg-amber-50 text-amber-700 dark:bg-amber-900/30 dark:text-amber-200",
+  ok: "bg-emerald-50 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-200",
+};
+
+export default function PortalPage() {
+  const pinned = notices.filter((n) => n.pinned);
+  const latest = notices.filter((n) => !n.pinned).slice(0, 4);
+
+  return (
+    <div className="space-y-6">
+      <section className="rounded-2xl bg-gradient-to-r from-primary-700 to-primary-500 px-6 py-7 text-white shadow-sm">
+        <div className="flex flex-wrap items-start justify-between gap-4">
+          <div>
+            <h1 className="text-2xl font-bold tracking-tight">社内ポータル</h1>
+            <p className="mt-2 text-sm text-primary-50/90">
+              お知らせ・イベント・各種手続きをまとめて確認できます。
+            </p>
+          </div>
+          <div className="flex flex-wrap items-center gap-2 text-xs">
+            <span className="rounded-full bg-white/20 px-3 py-1">本日 {new Date().toLocaleDateString("ja-JP")}</span>
+            <span className="rounded-full bg-white/20 px-3 py-1">ServiceHub v1.0</span>
+          </div>
+        </div>
+      </section>
+
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
+        <section className="rounded-xl border border-gray-200 bg-white p-5 shadow-sm dark:border-gray-700 dark:bg-gray-900 lg:col-span-2">
+          <header className="mb-4 flex items-center justify-between">
+            <h2 className="flex items-center gap-2 text-lg font-semibold text-gray-900 dark:text-white">
+              <Bell className="h-5 w-5 text-primary-600 dark:text-primary-400" aria-hidden="true" />
+              お知らせ
+            </h2>
+            <Link to="/notices" className="flex items-center gap-1 text-sm text-primary-600 hover:underline dark:text-primary-400">
+              一覧を見る
+              <ChevronRight className="h-4 w-4" aria-hidden="true" />
+            </Link>
+          </header>
+
+          <ul className="space-y-2">
+            {pinned.map((n) => (
+              <li
+                key={n.id}
+                className="flex items-start justify-between gap-3 rounded-lg bg-amber-50 px-3 py-2 dark:bg-amber-900/20"
+              >
+                <div className="min-w-0">
+                  <span className={`mr-2 inline-flex rounded-full px-2 py-0.5 text-xs font-medium ${categoryTone[n.cat]}`}>
+                    {n.cat}
+                  </span>
+                  <span className="text-sm font-medium text-gray-900 dark:text-white">{n.title}</span>
+                </div>
+                <time className="shrink-0 text-xs text-gray-500 dark:text-gray-400">{n.date}</time>
+              </li>
+            ))}
+            {latest.map((n) => (
+              <li
+                key={n.id}
+                className="flex items-start justify-between gap-3 rounded-lg px-3 py-2 hover:bg-gray-50 dark:hover:bg-gray-800"
+              >
+                <div className="min-w-0">
+                  <span className={`mr-2 inline-flex rounded-full px-2 py-0.5 text-xs font-medium ${categoryTone[n.cat]}`}>
+                    {n.cat}
+                  </span>
+                  <span className="text-sm text-gray-800 dark:text-gray-200">{n.title}</span>
+                </div>
+                <time className="shrink-0 text-xs text-gray-500 dark:text-gray-400">{n.date}</time>
+              </li>
+            ))}
+          </ul>
+        </section>
+
+        <section className="rounded-xl border border-gray-200 bg-white p-5 shadow-sm dark:border-gray-700 dark:bg-gray-900">
+          <header className="mb-4 flex items-center gap-2">
+            <Calendar className="h-5 w-5 text-primary-600 dark:text-primary-400" aria-hidden="true" />
+            <h2 className="text-lg font-semibold text-gray-900 dark:text-white">直近のイベント</h2>
+          </header>
+          <ul className="space-y-2">
+            {events.map((e) => (
+              <li key={`${e.date}-${e.title}`} className="flex items-center gap-3">
+                <div className={`flex h-12 w-14 flex-col items-center justify-center rounded-lg ${eventTone[e.color]}`}>
+                  <span className="text-sm font-bold tabular-nums">{e.date}</span>
+                  <span className="text-[10px]">{e.day}</span>
+                </div>
+                <div className="min-w-0 flex-1">
+                  <p className="truncate text-sm font-medium text-gray-900 dark:text-white">{e.title}</p>
+                  <p className="text-xs text-gray-500 dark:text-gray-400">{e.loc}</p>
+                </div>
+              </li>
+            ))}
+          </ul>
+        </section>
+      </div>
+
+      <section className="rounded-xl border border-gray-200 bg-white p-5 shadow-sm dark:border-gray-700 dark:bg-gray-900">
+        <h2 className="mb-4 text-lg font-semibold text-gray-900 dark:text-white">クイックリンク</h2>
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-4 lg:grid-cols-8">
+          {quickLinks.map(({ label, icon: Icon }) => (
+            <button
+              key={label}
+              type="button"
+              className="flex flex-col items-center gap-2 rounded-lg border border-gray-200 px-3 py-4 text-center transition-colors hover:border-primary-300 hover:bg-primary-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 dark:border-gray-700 dark:hover:border-primary-600 dark:hover:bg-primary-900/20"
+            >
+              <Icon className="h-6 w-6 text-primary-600 dark:text-primary-300" aria-hidden="true" />
+              <span className="text-xs font-medium text-gray-700 dark:text-gray-200">{label}</span>
+            </button>
+          ))}
+        </div>
+      </section>
+
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+        <section className="rounded-xl border border-gray-200 bg-white p-5 shadow-sm dark:border-gray-700 dark:bg-gray-900">
+          <h2 className="mb-3 flex items-center gap-2 text-lg font-semibold text-gray-900 dark:text-white">
+            <PartyPopper className="h-5 w-5 text-pink-500" aria-hidden="true" />
+            今月のお誕生日
+          </h2>
+          <ul className="space-y-2">
+            {birthdays.map((b) => (
+              <li key={b.name} className="flex items-center justify-between rounded-md px-2 py-1.5 hover:bg-gray-50 dark:hover:bg-gray-800">
+                <div>
+                  <p className="text-sm font-medium text-gray-900 dark:text-white">{b.name}</p>
+                  <p className="text-xs text-gray-500 dark:text-gray-400">{b.dept}</p>
+                </div>
+                <span className="text-sm text-pink-600 tabular-nums dark:text-pink-300">{b.date}</span>
+              </li>
+            ))}
+          </ul>
+        </section>
+
+        <section className="rounded-xl border border-gray-200 bg-white p-5 shadow-sm dark:border-gray-700 dark:bg-gray-900">
+          <h2 className="mb-3 flex items-center gap-2 text-lg font-semibold text-gray-900 dark:text-white">
+            <Sparkles className="h-5 w-5 text-emerald-500" aria-hidden="true" />
+            新入社員のご紹介
+          </h2>
+          <ul className="space-y-2">
+            {newHires.map((m) => (
+              <li key={m.name} className="flex items-center justify-between rounded-md px-2 py-1.5 hover:bg-gray-50 dark:hover:bg-gray-800">
+                <div>
+                  <p className="text-sm font-medium text-gray-900 dark:text-white">{m.name}</p>
+                  <p className="text-xs text-gray-500 dark:text-gray-400">{m.dept}</p>
+                </div>
+                <span className="text-sm text-emerald-600 tabular-nums dark:text-emerald-300">{m.date}</span>
+              </li>
+            ))}
+          </ul>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/internal/RulesPage.tsx
+++ b/frontend/src/pages/internal/RulesPage.tsx
@@ -1,0 +1,116 @@
+import { useState } from "react";
+import { FileText, History, Search } from "lucide-react";
+import { ruleCategories, ruleRevisions } from "./_fixtures";
+
+export default function RulesPage() {
+  const [query, setQuery] = useState("");
+  const filteredCategories = ruleCategories.filter((c) =>
+    query.trim() === "" ? true : c.label.includes(query.trim()) || c.desc.includes(query.trim()),
+  );
+
+  return (
+    <div className="space-y-6">
+      <header className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="space-y-1">
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-white">社内規程</h1>
+          <p className="text-sm text-gray-600 dark:text-gray-400">
+            就業規則・給与・安全衛生などの社内規程と改訂履歴を確認できます。
+          </p>
+        </div>
+        <label className="relative flex w-full items-center sm:w-72">
+          <Search className="pointer-events-none absolute left-3 h-4 w-4 text-gray-400" aria-hidden="true" />
+          <input
+            type="search"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="規程カテゴリを検索"
+            className="w-full rounded-md border border-gray-300 bg-white py-2 pl-9 pr-3 text-sm text-gray-900 placeholder:text-gray-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 dark:border-gray-700 dark:bg-gray-900 dark:text-white"
+          />
+        </label>
+      </header>
+
+      <section aria-label="規程カテゴリ" className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {filteredCategories.length === 0 ? (
+          <p className="col-span-full rounded-lg border border-dashed border-gray-300 py-8 text-center text-sm text-gray-500 dark:border-gray-700 dark:text-gray-400">
+            条件に一致する規程カテゴリはありません
+          </p>
+        ) : (
+          filteredCategories.map(({ icon: Icon, label, count, desc }) => (
+            <button
+              key={label}
+              type="button"
+              className="group flex items-start gap-3 rounded-xl border border-gray-200 bg-white p-5 text-left shadow-sm transition-colors hover:border-primary-300 hover:bg-primary-50/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 dark:border-gray-700 dark:bg-gray-900 dark:hover:border-primary-600 dark:hover:bg-primary-900/20"
+            >
+              <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-primary-50 text-primary-600 dark:bg-primary-900/40 dark:text-primary-300">
+                <Icon className="h-5 w-5" aria-hidden="true" />
+              </span>
+              <span className="min-w-0 flex-1">
+                <span className="flex items-center justify-between gap-2">
+                  <span className="text-sm font-semibold text-gray-900 dark:text-white">{label}</span>
+                  <span className="shrink-0 rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-600 tabular-nums dark:bg-gray-800 dark:text-gray-300">
+                    {count} 条
+                  </span>
+                </span>
+                <span className="mt-1 block text-xs text-gray-500 dark:text-gray-400">{desc}</span>
+              </span>
+            </button>
+          ))
+        )}
+      </section>
+
+      <section className="grid grid-cols-1 gap-6 lg:grid-cols-5">
+        <div className="rounded-xl border border-gray-200 bg-white p-5 shadow-sm dark:border-gray-700 dark:bg-gray-900 lg:col-span-3">
+          <header className="mb-4 flex items-center gap-2">
+            <History className="h-5 w-5 text-primary-600 dark:text-primary-400" aria-hidden="true" />
+            <h2 className="text-lg font-semibold text-gray-900 dark:text-white">最近の改訂</h2>
+          </header>
+          <ul className="divide-y divide-gray-200 dark:divide-gray-700">
+            {ruleRevisions.map((r) => (
+              <li
+                key={`${r.title}-${r.ver}`}
+                className="flex flex-col gap-1 py-3 sm:flex-row sm:items-center sm:justify-between"
+              >
+                <div className="min-w-0">
+                  <p className="truncate text-sm font-medium text-gray-900 dark:text-white">{r.title}</p>
+                  <p className="mt-0.5 text-xs text-gray-500 dark:text-gray-400">{r.diff}</p>
+                </div>
+                <div className="flex shrink-0 items-center gap-3 text-xs text-gray-500 dark:text-gray-400">
+                  <span className="rounded-full bg-primary-50 px-2 py-0.5 font-medium text-primary-700 dark:bg-primary-900/40 dark:text-primary-200">
+                    {r.ver}
+                  </span>
+                  <time className="tabular-nums">{r.date}</time>
+                </div>
+              </li>
+            ))}
+          </ul>
+        </div>
+
+        <aside className="rounded-xl border border-gray-200 bg-white p-5 shadow-sm dark:border-gray-700 dark:bg-gray-900 lg:col-span-2">
+          <header className="mb-3 flex items-center gap-2">
+            <FileText className="h-5 w-5 text-primary-600 dark:text-primary-400" aria-hidden="true" />
+            <h2 className="text-lg font-semibold text-gray-900 dark:text-white">様式・申請書</h2>
+          </header>
+          <ul className="space-y-2 text-sm">
+            {[
+              "有給休暇申請書",
+              "出張申請書",
+              "テレワーク申請書",
+              "慶弔見舞金申請書",
+              "社員通勤経路変更届",
+            ].map((label) => (
+              <li key={label}>
+                <button
+                  type="button"
+                  className="flex w-full items-center justify-between rounded-md px-3 py-2 text-left text-gray-800 transition-colors hover:bg-primary-50 hover:text-primary-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 dark:text-gray-200 dark:hover:bg-primary-900/20 dark:hover:text-primary-200"
+                >
+                  <span>{label}</span>
+                  <span className="text-xs text-gray-400">PDF</span>
+                </button>
+              </li>
+            ))}
+          </ul>
+        </aside>
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/pages/internal/_fixtures.ts
+++ b/frontend/src/pages/internal/_fixtures.ts
@@ -1,0 +1,237 @@
+import type { LucideIcon } from "lucide-react";
+import {
+  AlertTriangle,
+  Building,
+  Book,
+  Calendar,
+  Clock,
+  Coins,
+  FileText,
+  Settings,
+  Shield,
+  Users,
+} from "lucide-react";
+
+export type NoticeCategory =
+  | "重要"
+  | "人事"
+  | "ITSM"
+  | "福利厚生"
+  | "規程"
+  | "安全";
+
+export interface Notice {
+  id: number;
+  pinned: boolean;
+  cat: NoticeCategory;
+  title: string;
+  date: string;
+  by: string;
+  readCount?: [number, number];
+}
+
+export interface EventItem {
+  date: string;
+  day: string;
+  title: string;
+  loc: string;
+  color: string;
+}
+
+export interface QuickLink {
+  label: string;
+  icon: LucideIcon;
+  href?: string;
+}
+
+export interface HRKpi {
+  label: string;
+  value: string;
+  sub: string;
+  tone?: "ok" | "warn" | "err";
+}
+
+export interface HRMenu {
+  icon: LucideIcon;
+  label: string;
+  desc: string;
+}
+
+export interface Application {
+  kind: string;
+  period: string;
+  appliedAt: string;
+  approver: string;
+  status: "承認待ち" | "承認済" | "差戻し";
+  tone: "warn" | "ok" | "err";
+}
+
+export interface RuleCategory {
+  icon: LucideIcon;
+  label: string;
+  count: number;
+  desc: string;
+}
+
+export interface RuleRevision {
+  title: string;
+  ver: string;
+  date: string;
+  diff: string;
+}
+
+export interface BirthdayMember {
+  name: string;
+  date: string;
+  dept: string;
+}
+
+export const notices: Notice[] = [
+  {
+    id: 1,
+    pinned: true,
+    cat: "重要",
+    title: "2026 年度 安全衛生方針の公開について",
+    date: "2026-04-15",
+    by: "安全管理部",
+    readCount: [128, 180],
+  },
+  {
+    id: 2,
+    pinned: true,
+    cat: "人事",
+    title: "新入社員配属先のお知らせ（2026 年 4 月入社）",
+    date: "2026-04-12",
+    by: "人事部",
+    readCount: [145, 180],
+  },
+  {
+    id: 3,
+    pinned: false,
+    cat: "ITSM",
+    title: "社内システム定期メンテナンス（4/27 22:00-24:00）",
+    date: "2026-04-10",
+    by: "情報システム部",
+  },
+  {
+    id: 4,
+    pinned: false,
+    cat: "福利厚生",
+    title: "健康診断 2026 年度スケジュール確定のご案内",
+    date: "2026-04-08",
+    by: "総務部",
+  },
+  {
+    id: 5,
+    pinned: false,
+    cat: "規程",
+    title: "テレワーク規程改訂（2026-05-01 施行）",
+    date: "2026-04-05",
+    by: "総務部",
+  },
+  {
+    id: 6,
+    pinned: false,
+    cat: "安全",
+    title: "熱中症対策ガイドライン更新",
+    date: "2026-04-02",
+    by: "安全管理部",
+  },
+];
+
+export const events: EventItem[] = [
+  { date: "4/22", day: "火", title: "月次全社朝礼", loc: "本社 3F 会議室", color: "brand" },
+  { date: "4/25", day: "金", title: "安全パトロール", loc: "第 2 現場", color: "safety" },
+  { date: "4/27", day: "日", title: "システムメンテナンス", loc: "オンライン", color: "warn" },
+  { date: "5/01", day: "木", title: "新テレワーク規程施行", loc: "—", color: "ok" },
+  { date: "5/10", day: "土", title: "ファミリーデイ", loc: "本社ビル", color: "brand" },
+];
+
+export const quickLinks: QuickLink[] = [
+  { label: "申請書類", icon: FileText },
+  { label: "就業規則", icon: Book },
+  { label: "安全マニュアル", icon: Shield },
+  { label: "経費精算", icon: Coins },
+  { label: "勤怠打刻", icon: Clock },
+  { label: "社員名簿", icon: Users },
+  { label: "施設予約", icon: Building },
+  { label: "設定", icon: Settings },
+];
+
+export const hrKpis: HRKpi[] = [
+  { label: "今月稼働日", value: "13 / 21", sub: "進捗 62%" },
+  { label: "有給残", value: "12.5 日", sub: "期末まで 5.2 ヶ月" },
+  { label: "超過勤務 (今月)", value: "8.5 h", sub: "月上限 45h", tone: "ok" },
+  { label: "承認待ち申請", value: "2 件", sub: "最古 3 日前", tone: "warn" },
+];
+
+export const hrMenus: HRMenu[] = [
+  { icon: Clock, label: "勤怠打刻", desc: "出退勤の登録" },
+  { icon: FileText, label: "各種申請", desc: "有休・出張・交通費" },
+  { icon: Coins, label: "給与明細", desc: "過去 12 ヶ月閲覧可能" },
+  { icon: Calendar, label: "勤務シフト", desc: "月次シフト表" },
+  { icon: Users, label: "社員名簿", desc: "部門・連絡先" },
+  { icon: Settings, label: "人事設定", desc: "届出情報変更" },
+];
+
+export const applications: Application[] = [
+  {
+    kind: "有給休暇",
+    period: "2026-04-24",
+    appliedAt: "2026-04-15",
+    approver: "山田 太郎",
+    status: "承認待ち",
+    tone: "warn",
+  },
+  {
+    kind: "出張申請",
+    period: "2026-04-28 〜 04-30",
+    appliedAt: "2026-04-14",
+    approver: "鈴木 花子",
+    status: "承認済",
+    tone: "ok",
+  },
+  {
+    kind: "交通費",
+    period: "2026-03 分",
+    appliedAt: "2026-04-02",
+    approver: "経理部",
+    status: "差戻し",
+    tone: "err",
+  },
+  {
+    kind: "在宅勤務",
+    period: "2026-04-20",
+    appliedAt: "2026-04-17",
+    approver: "山田 太郎",
+    status: "承認待ち",
+    tone: "warn",
+  },
+];
+
+export const ruleCategories: RuleCategory[] = [
+  { icon: Users, label: "就業規則", count: 24, desc: "勤務時間・休暇・服務規律" },
+  { icon: Coins, label: "給与・報酬規程", count: 12, desc: "給与体系・手当・賞与" },
+  { icon: Shield, label: "安全衛生規程", count: 18, desc: "労災予防・健康管理" },
+  { icon: FileText, label: "情報セキュリティ", count: 9, desc: "データ取扱・端末管理" },
+  { icon: AlertTriangle, label: "コンプライアンス", count: 7, desc: "反社会的勢力対応ほか" },
+  { icon: Building, label: "施設・車両", count: 11, desc: "利用ルール・予約" },
+];
+
+export const ruleRevisions: RuleRevision[] = [
+  { title: "テレワーク規程", ver: "v2.3", date: "2026-04-05", diff: "+3 条 / 改正 2 箇所" },
+  { title: "経費精算規程", ver: "v1.8", date: "2026-03-22", diff: "交通費区分を再定義" },
+  { title: "情報セキュリティ基本方針", ver: "v4.0", date: "2026-03-01", diff: "全面改訂" },
+  { title: "健康管理規程", ver: "v1.4", date: "2026-02-18", diff: "健診項目追加" },
+];
+
+export const birthdays: BirthdayMember[] = [
+  { name: "佐藤 健一", date: "4/20", dept: "安全管理部" },
+  { name: "田中 美咲", date: "4/23", dept: "工事部" },
+  { name: "伊藤 涼", date: "4/28", dept: "情報システム部" },
+];
+
+export const newHires: BirthdayMember[] = [
+  { name: "高橋 翔太", date: "4/01 入社", dept: "工事部" },
+  { name: "渡辺 美香", date: "4/01 入社", dept: "人事部" },
+];

--- a/state.json
+++ b/state.json
@@ -1,9 +1,9 @@
 {
-  "phase": "Phase 5c merged (PR #130 a98e179) / Phase 5a Docker merged — 次: Phase 5b Lighthouse or 5d codegen",
-  "loop": "Day18-Phase5c-PostMerge-Sync",
-  "loop_count": 131,
+  "phase": "Phase 5e-1 社内 4 ページ 実装完了 (Issue #132) — PR 準備中 / 先行: Phase 5a/5c merged",
+  "loop": "Day18-Phase5e1-InternalPages",
+  "loop_count": 132,
   "status": "active",
-  "last_updated": "2026-04-18T06:15:00Z",
+  "last_updated": "2026-04-18T17:20:00+09:00",
   "execution": {
     "start_time": "2026-04-18T13:57:32+09:00",
     "max_duration_minutes": 300,
@@ -34,13 +34,17 @@
   },
   "priorities": {
     "high": [
-      "Issue #126 Phase 5b: Lighthouse スコア改善 (LCP/CLS/INP)",
-      "docs/design/ WebUI.html と frontend/src/pages/* の差分分析 (canonical source 化)"
+      "Phase 5e-1 PR review → merge (Issue #132 / 社内 4 ページ)",
+      "Issue #126 Phase 5b: Lighthouse スコア改善 (LCP/CLS/INP)"
     ],
     "medium": [
+      "Issue #133 サイドバー 4 グループ化 (業務 / 運用 / 社内 / 管理)",
+      "Issue #134 Tailwind トークン統一 (brand-10..90 / safety / warn)",
       "Issue #128 Phase 5d: OpenAPI codegen 更新 (Frontend 型同期)"
     ],
     "low": [
+      "Issue #135 サイドバー brand カラー (デジタル庁準拠)",
+      "Playwright SIGTRAP 環境調査 (Phase 5e-1 E2E spec 実行不可)",
       "distroless Docker イメージ検討 (PR #129 follow-up)",
       "Trivy HIGH 0 検証 (PR #129 follow-up)"
     ]
@@ -53,8 +57,10 @@
   "metrics": {
     "backend_tests": 316,
     "frontend_tests": 270,
-    "e2e_tests": 202,
-    "total_tests": 788,
+    "e2e_tests": 206,
+    "e2e_tests_note": "Phase 5e-1 +4 (spec コミット済 / ローカル SIGTRAP で実行不可・環境要調査)",
+    "total_tests": 792,
+    "frontend_pages": 17,
     "api_endpoints": 53,
     "backend_coverage": 95,
     "frontend_coverage": 88
@@ -101,6 +107,23 @@
       "status": "planned",
       "issue": "#128",
       "priority": "P3"
+    },
+    "phase_5e1_internal_pages": {
+      "status": "pr_pending",
+      "issue": "#132",
+      "branch": "feat/phase5e1-internal-pages",
+      "scope": "docs/design/ServiceHub-WebUI.html 正ソース化に基づく社内グループ 4 ページ新設",
+      "pages_added": [
+        "/portal (社内ポータル — お知らせ / 直近イベント / クイックリンク)",
+        "/notices (お知らせ一覧 — カテゴリフィルタ / 重要フラグ)",
+        "/hr (人事・勤怠 — KPI 4 枚 / 手続きメニュー 6 / 最近の申請テーブル)",
+        "/rules (社内規程 — カテゴリ検索 / 最近の改訂 / 様式・申請書)"
+      ],
+      "e2e_blocker": {
+        "issue": "ローカル Playwright chromium launch が SIGTRAP で失敗",
+        "evidence": "chromium-1217 / chromium_headless_shell-1217 両方で再現 / --workers=1 でも再現",
+        "action": "env 調査 Issue 化、CI で別途検証予定"
+      }
     }
   },
   "phase4_status": {
@@ -109,14 +132,14 @@
     "phase_4c_e2e": {"status": "merged", "pr": "#123"}
   },
   "resume_point": {
-    "action": "chore PR (post-phase5c sync) merge 後 → docs/design/ 正ソース差分分析 → Phase 5b Lighthouse 着手",
-    "branch": "chore/post-phase5c-state-sync",
-    "next_phase": "Phase 5b Lighthouse または Phase 5d OpenAPI codegen"
+    "action": "Phase 5e-1 PR 作成 → Codex/CodeRabbit レビュー → admin merge → Phase 5b Lighthouse or #133 サイドバー 4 グループ化",
+    "branch": "feat/phase5e1-internal-pages",
+    "next_phase": "Issue #133 (サイドバーグループ化) → #126 Lighthouse → #128 codegen"
   },
   "current_sprint": {
     "phase": "Sprint 6 Phase 5",
     "completed_prs_phase5": ["PR#129", "PR#130"],
-    "in_review_phase5": [],
-    "next": "Issue #126 (Lighthouse) または #128 (OpenAPI codegen) 着手 / docs/design/ 差分分析"
+    "in_review_phase5": ["Phase 5e-1 (PR 作成予定 / Issue #132)"],
+    "next": "Phase 5e-1 merge 後: Issue #133 (サイドバー 4 グループ化) / #126 Lighthouse / #128 codegen"
   }
 }


### PR DESCRIPTION
## Summary

Issue #132 — `docs/design/ServiceHub-WebUI.html` を正ソースとした社内グループ 4 ページを新設。
Sidebar 4 グループ構成 (業務 / 運用 / **社内** / 管理) の「社内」ブロックを実装する。

- `/portal`  社内ポータル — お知らせ / 直近イベント / クイックリンク
- `/notices` お知らせ一覧 — カテゴリフィルタ (全/重要/システム/安全/総務/人事)
- `/hr`      人事・勤怠 — KPI 4 枚 / 手続きメニュー 6 / 最近の申請テーブル
- `/rules`   社内規程 — カテゴリ検索 / 最近の改訂 / 様式・申請書

## 変更内容

### feat (`06c510f`)
- `frontend/src/pages/internal/{PortalPage,NoticesPage,HRPage,RulesPage,_fixtures}.tsx` 新規
- `frontend/src/components/layout/Layout.tsx` — Home/Newspaper/UserCog/BookText アイコン + 4 nav 追加
- `frontend/src/App.tsx` — Layout 配下に 4 Route 登録 (settings の前)

### test (`6c2c887`)
- `frontend/e2e/phase5e1-internal-pages.spec.ts` — smoke 4 件 (+4)
  - 見出し / aria-pressed フィルタ / KPI 表示 / placeholder 検索動作

### docs (`c79801b`)
- `README.md` — E2E 202→206 / 総テスト 788→792 / pages 13→17
- `docs/design/README.md` — 実装対応表 12 → 16 行 / 更新履歴 v1.1 追記
- `state.json` — Phase 5e-1 セクション追加 / priorities 再構成 / resume_point 更新

## テスト結果

- ✅ `npx tsc --noEmit` green
- ✅ `npx eslint --max-warnings 0` green (pages/internal + App + Layout)
- ⚠️ Playwright E2E: **ローカル実行不可** — Chromium 起動時 SIGTRAP
  - 再現条件: chromium-1217 / chromium_headless_shell-1217 両方 / `--workers=1` でも再現
  - spec はコミット済み。CI (`frontend-e2e` workflow) にて検証予定
  - 環境調査は follow-up Issue 起票予定

## 影響範囲

- 既存ページ・既存 Route は非破壊
- fixture ベースの reference 実装のためバックエンド変更なし
- ADMIN 限定表示なし (全ロール閲覧可)

## 残課題

- [ ] CI の E2E 結果確認 (SIGTRAP がローカル固有か CI でも発生するか)
- [ ] ローカル Playwright 環境調査 (follow-up Issue)
- [ ] 後続: Issue #133 (Sidebar 4 グループ化) / #134 (Tailwind トークン統一) / #135 (brand カラー)

## Test plan

- [ ] CI `frontend-build` green
- [ ] CI `frontend-e2e` 実行結果確認 (Phase 5e-1 spec 含む)
- [ ] CI `frontend-lint` green
- [ ] CodeRabbit 指摘整理
- [ ] Codex review 指摘整理

Closes #132

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **New Features**
  * 4つの新しい内部ページを追加：ポータル／お知らせ／人事・勤怠／社内規程
  * お知らせページに検索・カテゴリフィルタリング、社内規程にカテゴリ検索と最近の改訂一覧を追加
  * サイドバーに新ページへのメニューを追加

* **Tests**
  * E2Eスモークテストを4件追加（E2E件数 202→206、総テスト 788→792）

* **Documentation**
  * ドキュメントとREADMEのページ一覧・説明を更新（内部グループを明記）
<!-- end of auto-generated comment: release notes by coderabbit.ai -->