### PR TITLE
chore(phase5e1): post-merge sync — state.json + README 反映

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ graph TB
 | ✅ CI チェック数 | **15 チェック**（ruff / mypy / pytest / bandit / vitest / build / E2E / dependency / type-check x2 / test-coverage x2 / lint-build x2 + Lighthouse CI） |
 | 📊 Prometheus メトリクス | **有効**（`/metrics` エンドポイント / 全ルート RED メトリクス自動計測） |
 | ⚡ Web Vitals | **有効**（LCP / INP / CLS / TTFB / FCP / web-vitals v5） |
-| 🔒 STABLE 判定 | **達成**（main CI 全 success / Phase 3a PR#110 / 3b PR#111 / 3c PR#113 / 3d PR#115 / Phase 4a PR#119 / 4b PR#121 / 4c PR#123 / Phase 5a PR#129 Docker / Phase 5c PR#130 coverage 95% 全 merge 済み） |
+| 🔒 STABLE 判定 | **達成**（main CI 全 success / Phase 3a PR#110 / 3b PR#111 / 3c PR#113 / 3d PR#115 / Phase 4a PR#119 / 4b PR#121 / 4c PR#123 / Phase 5a PR#129 Docker / Phase 5c PR#130 coverage 95% / Phase 5e-1 PR#136 社内 4 ページ 全 merge 済み） |
 
 ### 🏗️ Backend アーキテクチャ
 
@@ -259,7 +259,7 @@ graph LR
 | `notification-settings.spec.ts` | 6 | 通知設定 UI (マスタースイッチ・イベント別・保存) |
 | `notification-panel.spec.ts` | 11 | 通知バッジ表示・パネル開閉・SSE 受信・未読カウント・すべてクリア・アクセシビリティ |
 | `phase5e1-internal-pages.spec.ts` | 4 | 社内ポータル / お知らせ / 人事・勤怠 / 社内規程 — 見出し・セクション・フィルタ smoke (Phase 5e-1) |
-| **合計** | **206** | **全16ページ E2E + CRUD + 認証フロー + AI検索 + エラー境界 + 通知設定 + 通知パネル(Phase 4c) + 社内グループ(Phase 5e-1)** |
+| **合計** | **206** | **全17ページ E2E + CRUD + 認証フロー + AI検索 + エラー境界 + 通知設定 + 通知パネル(Phase 4c) + 社内グループ(Phase 5e-1)** |
 
 ---
 

--- a/state.json
+++ b/state.json
@@ -1,9 +1,9 @@
 {
-  "phase": "Phase 5e-1 社内 4 ページ 実装完了 (Issue #132) — PR 準備中 / 先行: Phase 5a/5c merged",
-  "loop": "Day18-Phase5e1-InternalPages",
-  "loop_count": 132,
+  "phase": "Phase 5e-1 社内 4 ページ merged (PR#136 / 3fb86d2) — 次: Issue #133 Sidebar 4 グループ化 or Phase 5b Lighthouse",
+  "loop": "Day18-PostPhase5e1-Sync",
+  "loop_count": 133,
   "status": "active",
-  "last_updated": "2026-04-18T17:20:00+09:00",
+  "last_updated": "2026-04-18T16:35:00+09:00",
   "execution": {
     "start_time": "2026-04-18T13:57:32+09:00",
     "max_duration_minutes": 300,
@@ -34,16 +34,15 @@
   },
   "priorities": {
     "high": [
-      "Phase 5e-1 PR review → merge (Issue #132 / 社内 4 ページ)",
+      "Issue #133 サイドバー 4 グループ化 (業務 / 運用 / 社内 / 管理)",
       "Issue #126 Phase 5b: Lighthouse スコア改善 (LCP/CLS/INP)"
     ],
     "medium": [
-      "Issue #133 サイドバー 4 グループ化 (業務 / 運用 / 社内 / 管理)",
       "Issue #134 Tailwind トークン統一 (brand-10..90 / safety / warn)",
-      "Issue #128 Phase 5d: OpenAPI codegen 更新 (Frontend 型同期)"
+      "Issue #128 Phase 5d: OpenAPI codegen 更新 (Frontend 型同期)",
+      "Issue #135 サイドバー brand カラー (デジタル庁準拠)"
     ],
     "low": [
-      "Issue #135 サイドバー brand カラー (デジタル庁準拠)",
       "Playwright SIGTRAP 環境調査 (Phase 5e-1 E2E spec 実行不可)",
       "distroless Docker イメージ検討 (PR #129 follow-up)",
       "Trivy HIGH 0 検証 (PR #129 follow-up)"
@@ -109,9 +108,12 @@
       "priority": "P3"
     },
     "phase_5e1_internal_pages": {
-      "status": "pr_pending",
+      "status": "merged",
+      "pr": "#136",
       "issue": "#132",
-      "branch": "feat/phase5e1-internal-pages",
+      "merged_at": "2026-04-18T07:22:11Z",
+      "merge_commit": "3fb86d2",
+      "branch": "feat/phase5e1-internal-pages (deleted)",
       "scope": "docs/design/ServiceHub-WebUI.html 正ソース化に基づく社内グループ 4 ページ新設",
       "pages_added": [
         "/portal (社内ポータル — お知らせ / 直近イベント / クイックリンク)",
@@ -119,11 +121,11 @@
         "/hr (人事・勤怠 — KPI 4 枚 / 手続きメニュー 6 / 最近の申請テーブル)",
         "/rules (社内規程 — カテゴリ検索 / 最近の改訂 / 様式・申請書)"
       ],
-      "e2e_blocker": {
-        "issue": "ローカル Playwright chromium launch が SIGTRAP で失敗",
-        "evidence": "chromium-1217 / chromium_headless_shell-1217 両方で再現 / --workers=1 でも再現",
-        "action": "env 調査 Issue 化、CI で別途検証予定"
-      }
+      "e2e_added": 4,
+      "ci_result": "E2E 10/10 PASS (post selector fix 1169ac6)",
+      "follow_ups": [
+        "ローカル Playwright chromium SIGTRAP 環境調査 (CI では未再現)"
+      ]
     }
   },
   "phase4_status": {
@@ -132,14 +134,14 @@
     "phase_4c_e2e": {"status": "merged", "pr": "#123"}
   },
   "resume_point": {
-    "action": "Phase 5e-1 PR 作成 → Codex/CodeRabbit レビュー → admin merge → Phase 5b Lighthouse or #133 サイドバー 4 グループ化",
-    "branch": "feat/phase5e1-internal-pages",
-    "next_phase": "Issue #133 (サイドバーグループ化) → #126 Lighthouse → #128 codegen"
+    "action": "Issue #133 Sidebar 4 グループ化 着手 (業務/運用/社内/管理 分離) — or Phase 5b Lighthouse #126",
+    "branch": "(次 Issue 用 worktree 新規作成)",
+    "next_phase": "#133 Sidebar → #126 Lighthouse → #134 Tailwind token → #128 codegen"
   },
   "current_sprint": {
     "phase": "Sprint 6 Phase 5",
-    "completed_prs_phase5": ["PR#129", "PR#130"],
-    "in_review_phase5": ["Phase 5e-1 (PR 作成予定 / Issue #132)"],
-    "next": "Phase 5e-1 merge 後: Issue #133 (サイドバー 4 グループ化) / #126 Lighthouse / #128 codegen"
+    "completed_prs_phase5": ["PR#129", "PR#130", "PR#136"],
+    "in_review_phase5": [],
+    "next": "Issue #133 サイドバー 4 グループ化 / #126 Lighthouse / #128 codegen"
   }
 }


### PR DESCRIPTION
## Summary

Phase 5e-1 (PR#136 / 3fb86d2) merged の事実を state.json と README に反映する post-merge sync PR。PR #131 (post-phase5c-state-sync) と同じ運用パターン。

## 変更内容

### `state.json`
- `phase` ラベル: `"PR 準備中"` → `"merged (PR#136 / 3fb86d2) — 次: Issue #133 or Phase 5b"`
- `loop` / `loop_count`: `Day18-Phase5e1-InternalPages / 132` → `Day18-PostPhase5e1-Sync / 133`
- `priorities.high`: `Phase 5e-1 PR review → merge` を削除、Issue #133 Sidebar 4 グループ化を high へ昇格
- `priorities.medium` / `low`: Issue #135 を medium へ移動 (Playwright SIGTRAP 調査のみ low 残留)
- `phase5_status.phase_5e1_internal_pages`: `pr_pending` → `merged`
  - `pr: "#136"` / `merged_at: "2026-04-18T07:22:11Z"` / `merge_commit: "3fb86d2"` 追加
  - `e2e_blocker` → `follow_ups` にリネーム (ローカル SIGTRAP は CI unreproducible なので継続調査枠)
  - `e2e_added: 4` / `ci_result: "E2E 10/10 PASS (post selector fix 1169ac6)"` 追加
- `resume_point`: 次アクション = Issue #133 Sidebar 4 グループ化 or #126 Lighthouse
- `current_sprint.completed_prs_phase5`: `PR#136` 追加、`in_review_phase5` を空配列に

### `README.md`
- `🔒 STABLE 判定` 欄: `Phase 5e-1 PR#136 社内 4 ページ` を merge 済みリストに追記
- E2E 合計行: `全16ページ E2E` → `全17ページ E2E` (Phase 5e-1 で +4 ページ分)

## テスト結果

- ドキュメント/設定のみの変更 (state.json + README.md)
- `python3 -c 'import json; json.load(open(\"state.json\"))'` → OK
- コード変更なしのため unit/E2E への影響なし

## 影響範囲

- `state.json`: ClaudeOS v8 ループ意思決定入力。次セッション再開時に誤った優先順位で動かないための真実更新
- `README.md`: 外向け可視化。Phase 5e-1 merged を STABLE 判定リストに反映

## 残課題

- Issue #133 Sidebar 4 グループ化 (次タスク / high)
- Issue #126 Phase 5b Lighthouse (high)
- ローカル Playwright chromium SIGTRAP 環境調査 (low / CI unreproducible)

## Test plan

- [x] state.json が valid JSON である
- [x] README の STABLE 判定欄に PR#136 が含まれる
- [x] E2E 合計行が「全17ページ」になっている
- [x] diff が最小 (2 files / +25 -23)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * プロジェクトの進捗状況と完了条件を更新しました。

* **Chores**
  * ワークフロー状態管理ファイルを更新し、フェーズの進行とE2Eテスト結果を記録しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->