### PR TITLE
feat(phase5e2): Sidebar 4グループ構造化 — canonical navigation 反映 (Issue #133)

### DIFF
--- a/frontend/src/components/layout/Layout.tsx
+++ b/frontend/src/components/layout/Layout.tsx
@@ -30,6 +30,17 @@ import { NotificationBadge } from "@/components/ui/NotificationBadge";
 import { NotificationPanel } from "@/components/ui/NotificationPanel";
 import clsx from "clsx";
 
+type NavItem = {
+  to: string;
+  icon: typeof LayoutDashboard;
+  label: string;
+};
+
+type NavGroup = {
+  label: string;
+  items: NavItem[];
+};
+
 export default function Layout() {
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const [panelOpen, setPanelOpen] = useState(false);
@@ -44,26 +55,46 @@ export default function Layout() {
     clearUnread();
   };
 
-  const navItems = [
-    { to: "/dashboard", icon: LayoutDashboard, label: "ダッシュボード" },
-    { to: "/projects", icon: Building2, label: "工事案件" },
-    { to: "/reports", icon: FileText, label: "日報" },
-    { to: "/safety", icon: HardHat, label: "安全品質" },
-    { to: "/cost", icon: DollarSign, label: "原価管理" },
-    { to: "/photos", icon: Image, label: "写真管理" },
-    { to: "/itsm", icon: AlertCircle, label: "ITSM" },
-    { to: "/knowledge", icon: BookOpen, label: "ナレッジ" },
-    { to: "/portal", icon: Home, label: "社内ポータル" },
-    { to: "/notices", icon: Newspaper, label: "お知らせ" },
-    { to: "/hr", icon: UserCog, label: "人事・勤怠" },
-    { to: "/rules", icon: BookText, label: "社内規程" },
-    ...(user?.role === "ADMIN"
-      ? [
-          { to: "/users", icon: Users, label: "ユーザー管理" },
-          { to: "/admin/notifications", icon: Bell, label: "通知管理" },
-        ]
-      : []),
-    { to: "/settings", icon: Settings, label: "設定" },
+  const navGroups: NavGroup[] = [
+    {
+      label: "業務",
+      items: [
+        { to: "/dashboard", icon: LayoutDashboard, label: "ダッシュボード" },
+        { to: "/projects",  icon: Building2,        label: "工事案件" },
+        { to: "/reports",   icon: FileText,         label: "日報" },
+        { to: "/photos",    icon: Image,            label: "写真管理" },
+      ],
+    },
+    {
+      label: "運用",
+      items: [
+        { to: "/safety",    icon: HardHat,      label: "安全品質" },
+        { to: "/cost",      icon: DollarSign,   label: "原価管理" },
+        { to: "/itsm",      icon: AlertCircle,  label: "ITSM" },
+        { to: "/knowledge", icon: BookOpen,     label: "ナレッジ" },
+      ],
+    },
+    {
+      label: "社内",
+      items: [
+        { to: "/portal",  icon: Home,      label: "社内ポータル" },
+        { to: "/notices", icon: Newspaper, label: "お知らせ" },
+        { to: "/hr",      icon: UserCog,   label: "人事・勤怠" },
+        { to: "/rules",   icon: BookText,  label: "社内規程" },
+      ],
+    },
+    {
+      label: "管理",
+      items: [
+        ...(user?.role === "ADMIN"
+          ? [
+              { to: "/users",               icon: Users, label: "ユーザー管理" },
+              { to: "/admin/notifications", icon: Bell,  label: "通知管理" },
+            ]
+          : []),
+        { to: "/settings", icon: Settings, label: "設定" },
+      ],
+    },
   ];
 
   const handleLogout = () => {
@@ -71,15 +102,7 @@ export default function Layout() {
     navigate("/login");
   };
 
-  const NavLink = ({
-    to,
-    icon: Icon,
-    label,
-  }: {
-    to: string;
-    icon: typeof LayoutDashboard;
-    label: string;
-  }) => {
+  const NavLink = ({ to, icon: Icon, label }: NavItem) => {
     const active = location.pathname.startsWith(to);
     return (
       <Link
@@ -134,9 +157,18 @@ export default function Layout() {
           </div>
         </div>
 
-        <nav id="sidebar-nav" aria-label="メインナビゲーション" className="flex-1 px-3 py-4 space-y-1 overflow-y-auto">
-          {navItems.map((item) => (
-            <NavLink key={item.to} {...item} />
+        <nav id="sidebar-nav" aria-label="メインナビゲーション" className="flex-1 px-3 py-4 overflow-y-auto">
+          {navGroups.map((group, gi) => (
+            <div key={group.label} className={gi > 0 ? "mt-4" : ""}>
+              <div className="px-3 mb-1 text-xs font-semibold uppercase tracking-wider text-primary-300 dark:text-gray-500">
+                {group.label}
+              </div>
+              <div className="space-y-1">
+                {group.items.map((item) => (
+                  <NavLink key={item.to} {...item} />
+                ))}
+              </div>
+            </div>
           ))}
         </nav>
 


### PR DESCRIPTION
## Summary

- `Layout.tsx` のフラット `navItems` 配列 (15項目) を canonical `docs/design/ServiceHub-WebUI.html` L532-568 準拠の `NAV_GROUPS` 4グループ構造へ再構成
- グループヘッダー (業務 / 運用 / 社内 / 管理) を `px-3 text-xs uppercase tracking-wider` スタイルで追加
- `NavItem` / `NavGroup` 型定義を追加し型安全性を向上

## 変更内容

| 変更 | 詳細 |
|---|---|
| `navItems` → `navGroups: NavGroup[]` | 4グループ (業務/運用/社内/管理) に再構成 |
| グループヘッダー | `text-primary-300 dark:text-gray-500` で dark mode 対応済 |
| ADMIN 条件 | 管理グループの先頭2項目 (ユーザー管理/通知管理) に集約 |
| `NavLink` 型シグネチャ | インライン型 → `NavItem` 型エイリアス参照に簡略化 |

## グループ構造

```
業務: ダッシュボード / 工事案件 / 日報 / 写真管理
運用: 安全品質 / 原価管理 / ITSM / ナレッジ
社内: 社内ポータル / お知らせ / 人事・勤怠 / 社内規程  ← Issue #132 追加ページ
管理: ユーザー管理(ADMIN) / 通知管理(ADMIN) / 設定
```

## テスト結果

- TypeScript: CI `npm run build` (vite) で型検証
- E2E 29 spec: sidebar 構造変更に対してセレクター堅牢性確認済
  - `getByRole("link", { name: "設定" })` → `<Link>` 要素のみ、グループ `<div>` は非影響
  - `settings.spec.ts` `profileSection.getByText("管理者")` → section スコープで衝突なし
- dark mode: `dark:text-gray-500` 既存クラスで自動対応

## 影響範囲

- `frontend/src/components/layout/Layout.tsx` のみ (1ファイル)
- ルーター構造・ページコンポーネント変更なし
- E2E spec 変更なし

## 残課題

- Issue #126 Phase 5b Lighthouse スコア改善 (次候補)
- Issue #134 Phase 5e-3 Tailwind ブランドカラー token 整備
- Issue #135 Phase 5e-4 Sidebar 配色統一

Closes #133

## Test plan

- [ ] CI Lint & Build (vite) pass
- [ ] CI Test & Coverage pass
- [ ] CI E2E (Playwright) 29 spec all pass
- [ ] CodeRabbit review pass
- [ ] sidebar グループヘッダー UI 確認 (業務/運用/社内/管理)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * サイドバーナビゲーションをセクションごとにグループ化し、より分かりやすく整理しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->