### PR TITLE
feat(phase5b): Lighthouse スコア改善 — route-level code splitting + manualChunks

### DIFF
--- a/frontend/e2e/fixtures/api-mocks.ts
+++ b/frontend/e2e/fixtures/api-mocks.ts
@@ -327,4 +327,5 @@ export async function loginAndNavigate(page: Page): Promise<void> {
   )
   await page.goto('/dashboard')
   await page.waitForURL('**/dashboard')
+  await page.waitForSelector('main')
 }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="description" content="ServiceHub 工事管理プラットフォーム — 建設業向け統合管理システム" />
     <title>ServiceHub 工事管理プラットフォーム</title>
   </head>
   <body>

--- a/frontend/lighthouserc.js
+++ b/frontend/lighthouserc.js
@@ -1,39 +1,37 @@
 /**
- * Lighthouse CI configuration (Phase 3a — Performance Metrics)
+ * Lighthouse CI configuration (Phase 5b — Production Quality Targets)
  *
  * Runs against the static built dist directory so no server is required.
- * Thresholds are intentionally relaxed for initial baseline measurement.
- * Tighten after the first successful CI run establishes a baseline.
+ * Phase 5b targets: Performance ≥ 90, A11y ≥ 95, BP ≥ 95, SEO ≥ 90
+ * Core Web Vitals: LCP ≤ 2.5s, CLS ≤ 0.1, INP ≤ 200ms
  */
 
 /** @type {import('@lhci/cli').LighthouseConfig} */
 export default {
   ci: {
     collect: {
-      // Analyze the built static files without needing a running server
       staticDistDir: "./dist",
-      // Measure 3 times to reduce noise
       numberOfRuns: 3,
     },
     assert: {
       preset: "lighthouse:no-pwa",
       assertions: {
-        // Phase 3a: Baseline thresholds — tighten in Phase 3b after first pass
-        "categories:performance": ["warn", { minScore: 0.7 }],
-        "categories:accessibility": ["warn", { minScore: 0.8 }],
-        "categories:best-practices": ["warn", { minScore: 0.8 }],
-        "categories:seo": ["warn", { minScore: 0.7 }],
+        // Phase 5b: Production quality thresholds
+        "categories:performance": ["warn", { minScore: 0.9 }],
+        "categories:accessibility": ["warn", { minScore: 0.95 }],
+        "categories:best-practices": ["warn", { minScore: 0.95 }],
+        "categories:seo": ["warn", { minScore: 0.9 }],
         // Core Web Vitals
-        "first-contentful-paint": ["warn", { maxNumericValue: 3000 }],
-        "largest-contentful-paint": ["warn", { maxNumericValue: 4000 }],
+        "first-contentful-paint": ["warn", { maxNumericValue: 2000 }],
+        "largest-contentful-paint": ["warn", { maxNumericValue: 2500 }],
         "cumulative-layout-shift": ["warn", { maxNumericValue: 0.1 }],
-        // Block only on critical failures
-        "is-on-https": "off", // disabled for local/CI static serving
+        "total-blocking-time": ["warn", { maxNumericValue: 300 }],
+        // Disabled for CI static serving
+        "is-on-https": "off",
         "redirects-http": "off",
       },
     },
     upload: {
-      // Store reports as GitHub Actions artifacts (no server required)
       target: "filesystem",
       outputDir: "./lighthouse-reports",
     },

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -23,9 +23,9 @@ export default defineConfig({
     },
   ],
   webServer: {
-    command: `npx vite --port ${E2E_PORT}`,
+    command: `npx vite build && npx vite preview --port ${E2E_PORT}`,
     url: `http://localhost:${E2E_PORT}`,
     reuseExistingServer: !process.env.CI,
-    timeout: 30_000,
+    timeout: 120_000,
   },
 });

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { MemoryRouter } from "react-router-dom";
 import App from "./App";
@@ -31,7 +31,7 @@ describe("App", () => {
     vi.clearAllMocks();
   });
 
-  it("未認証の場合、/login にリダイレクトする", () => {
+  it("未認証の場合、/login にリダイレクトする", async () => {
     vi.mocked(useAuthStore).mockImplementation((selector: (s: { token: string | null }) => unknown) =>
       selector({ token: null }),
     );
@@ -40,10 +40,10 @@ describe("App", () => {
         <App />
       </MemoryRouter>,
     );
-    expect(screen.getByTestId("login-page")).toBeInTheDocument();
+    await waitFor(() => expect(screen.getByTestId("login-page")).toBeInTheDocument());
   });
 
-  it("/login にアクセスするとログインページが表示される", () => {
+  it("/login にアクセスするとログインページが表示される", async () => {
     vi.mocked(useAuthStore).mockImplementation((selector: (s: { token: string | null }) => unknown) =>
       selector({ token: null }),
     );
@@ -52,10 +52,10 @@ describe("App", () => {
         <App />
       </MemoryRouter>,
     );
-    expect(screen.getByTestId("login-page")).toBeInTheDocument();
+    await waitFor(() => expect(screen.getByTestId("login-page")).toBeInTheDocument());
   });
 
-  it("認証済みの場合、/ から /dashboard にリダイレクトする", () => {
+  it("認証済みの場合、/ から /dashboard にリダイレクトする", async () => {
     vi.mocked(useAuthStore).mockImplementation((selector: (s: { token: string | null }) => unknown) =>
       selector({ token: "test-token" }),
     );
@@ -64,10 +64,10 @@ describe("App", () => {
         <App />
       </MemoryRouter>,
     );
-    expect(screen.getByTestId("dashboard-page")).toBeInTheDocument();
+    await waitFor(() => expect(screen.getByTestId("dashboard-page")).toBeInTheDocument());
   });
 
-  it("認証済みの場合、/projects ページが表示される", () => {
+  it("認証済みの場合、/projects ページが表示される", async () => {
     vi.mocked(useAuthStore).mockImplementation((selector: (s: { token: string | null }) => unknown) =>
       selector({ token: "test-token" }),
     );
@@ -76,10 +76,10 @@ describe("App", () => {
         <App />
       </MemoryRouter>,
     );
-    expect(screen.getByTestId("projects-page")).toBeInTheDocument();
+    await waitFor(() => expect(screen.getByTestId("projects-page")).toBeInTheDocument());
   });
 
-  it("認証済みの場合、各ルートが正しくレンダリングされる", () => {
+  it("認証済みの場合、各ルートが正しくレンダリングされる", async () => {
     vi.mocked(useAuthStore).mockImplementation((selector: (s: { token: string | null }) => unknown) =>
       selector({ token: "test-token" }),
     );
@@ -99,7 +99,7 @@ describe("App", () => {
           <App />
         </MemoryRouter>,
       );
-      expect(screen.getByTestId(testId)).toBeInTheDocument();
+      await waitFor(() => expect(screen.getByTestId(testId)).toBeInTheDocument());
       unmount();
     }
   });

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,23 +1,35 @@
+import { lazy, Suspense } from "react";
 import { Routes, Route, Navigate } from "react-router-dom";
 import Layout from "@/components/layout/Layout";
-import LoginPage from "@/pages/auth/LoginPage";
-import DashboardPage from "@/pages/DashboardPage";
-import ProjectsPage from "@/pages/projects/ProjectsPage";
-import ProjectDetailPage from "@/pages/projects/ProjectDetailPage";
-import DailyReportsPage from "@/pages/reports/DailyReportsPage";
-import SafetyPage from "@/pages/safety/SafetyPage";
-import ItsmPage from "@/pages/itsm/ItsmPage";
-import KnowledgePage from "@/pages/knowledge/KnowledgePage";
-import CostPage from "@/pages/cost/CostPage";
-import PhotosPage from "@/pages/photos/PhotosPage";
-import UsersPage from "@/pages/users/UsersPage";
-import SettingsPage from "@/pages/settings/SettingsPage";
-import NotificationDeliveriesPage from "@/pages/notifications/NotificationDeliveriesPage";
-import PortalPage from "@/pages/internal/PortalPage";
-import NoticesPage from "@/pages/internal/NoticesPage";
-import HRPage from "@/pages/internal/HRPage";
-import RulesPage from "@/pages/internal/RulesPage";
 import { useAuthStore } from "@/stores/authStore";
+
+const LoginPage = lazy(() => import("@/pages/auth/LoginPage"));
+const DashboardPage = lazy(() => import("@/pages/DashboardPage"));
+const ProjectsPage = lazy(() => import("@/pages/projects/ProjectsPage"));
+const ProjectDetailPage = lazy(() => import("@/pages/projects/ProjectDetailPage"));
+const DailyReportsPage = lazy(() => import("@/pages/reports/DailyReportsPage"));
+const SafetyPage = lazy(() => import("@/pages/safety/SafetyPage"));
+const ItsmPage = lazy(() => import("@/pages/itsm/ItsmPage"));
+const KnowledgePage = lazy(() => import("@/pages/knowledge/KnowledgePage"));
+const CostPage = lazy(() => import("@/pages/cost/CostPage"));
+const PhotosPage = lazy(() => import("@/pages/photos/PhotosPage"));
+const UsersPage = lazy(() => import("@/pages/users/UsersPage"));
+const SettingsPage = lazy(() => import("@/pages/settings/SettingsPage"));
+const NotificationDeliveriesPage = lazy(
+  () => import("@/pages/notifications/NotificationDeliveriesPage"),
+);
+const PortalPage = lazy(() => import("@/pages/internal/PortalPage"));
+const NoticesPage = lazy(() => import("@/pages/internal/NoticesPage"));
+const HRPage = lazy(() => import("@/pages/internal/HRPage"));
+const RulesPage = lazy(() => import("@/pages/internal/RulesPage"));
+
+function PageFallback() {
+  return (
+    <div className="flex items-center justify-center min-h-[200px]" aria-label="読み込み中">
+      <div className="w-8 h-8 border-4 border-primary-600 border-t-transparent rounded-full animate-spin" />
+    </div>
+  );
+}
 
 function PrivateRoute({ children }: { children: React.ReactNode }) {
   const token = useAuthStore((s) => s.token);
@@ -26,37 +38,39 @@ function PrivateRoute({ children }: { children: React.ReactNode }) {
 
 export default function App() {
   return (
-    <Routes>
-      <Route path="/login" element={<LoginPage />} />
-      <Route
-        path="/"
-        element={
-          <PrivateRoute>
-            <Layout />
-          </PrivateRoute>
-        }
-      >
-        <Route index element={<Navigate to="/dashboard" replace />} />
-        <Route path="dashboard" element={<DashboardPage />} />
-        <Route path="projects" element={<ProjectsPage />} />
-        <Route path="projects/:id" element={<ProjectDetailPage />} />
-        <Route path="reports" element={<DailyReportsPage />} />
-        <Route path="safety" element={<SafetyPage />} />
-        <Route path="itsm" element={<ItsmPage />} />
-        <Route path="knowledge" element={<KnowledgePage />} />
-        <Route path="cost" element={<CostPage />} />
-        <Route path="photos" element={<PhotosPage />} />
-        <Route path="users" element={<UsersPage />} />
+    <Suspense fallback={<PageFallback />}>
+      <Routes>
+        <Route path="/login" element={<LoginPage />} />
         <Route
-          path="admin/notifications"
-          element={<NotificationDeliveriesPage />}
-        />
-        <Route path="portal" element={<PortalPage />} />
-        <Route path="notices" element={<NoticesPage />} />
-        <Route path="hr" element={<HRPage />} />
-        <Route path="rules" element={<RulesPage />} />
-        <Route path="settings" element={<SettingsPage />} />
-      </Route>
-    </Routes>
+          path="/"
+          element={
+            <PrivateRoute>
+              <Layout />
+            </PrivateRoute>
+          }
+        >
+          <Route index element={<Navigate to="/dashboard" replace />} />
+          <Route path="dashboard" element={<DashboardPage />} />
+          <Route path="projects" element={<ProjectsPage />} />
+          <Route path="projects/:id" element={<ProjectDetailPage />} />
+          <Route path="reports" element={<DailyReportsPage />} />
+          <Route path="safety" element={<SafetyPage />} />
+          <Route path="itsm" element={<ItsmPage />} />
+          <Route path="knowledge" element={<KnowledgePage />} />
+          <Route path="cost" element={<CostPage />} />
+          <Route path="photos" element={<PhotosPage />} />
+          <Route path="users" element={<UsersPage />} />
+          <Route
+            path="admin/notifications"
+            element={<NotificationDeliveriesPage />}
+          />
+          <Route path="portal" element={<PortalPage />} />
+          <Route path="notices" element={<NoticesPage />} />
+          <Route path="hr" element={<HRPage />} />
+          <Route path="rules" element={<RulesPage />} />
+          <Route path="settings" element={<SettingsPage />} />
+        </Route>
+      </Routes>
+    </Suspense>
   );
 }

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -9,6 +9,10 @@ export default defineConfig({
       "@": path.resolve(__dirname, "./src"),
     },
   },
+  // Preserve class/function names so E2E tests can find React fiber nodes by name
+  esbuild: {
+    keepNames: true,
+  },
   build: {
     rollupOptions: {
       output: {

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -9,6 +9,19 @@ export default defineConfig({
       "@": path.resolve(__dirname, "./src"),
     },
   },
+  build: {
+    rollupOptions: {
+      output: {
+        manualChunks: {
+          "vendor-react": ["react", "react-dom", "react-router-dom"],
+          "vendor-query": ["@tanstack/react-query"],
+          "vendor-charts": ["recharts"],
+          "vendor-forms": ["react-hook-form", "@hookform/resolvers", "zod"],
+          "vendor-icons": ["lucide-react"],
+        },
+      },
+    },
+  },
   server: {
     port: 3000,
     proxy: {


### PR DESCRIPTION
## 変更内容

Issue #126 Phase 5b: Lighthouse スコア改善 (LCP/CLS/INP)

### 実装

| ファイル | 変更内容 |
|---|---|
| `frontend/src/App.tsx` | 全ページを `React.lazy()` + `Suspense` で route-based lazy loading に変換 |
| `frontend/vite.config.ts` | `manualChunks` で vendor 分割 (react/query/charts/forms/icons) |
| `frontend/lighthouserc.js` | Phase 5b 目標しきい値へ更新 |
| `frontend/index.html` | `meta description` 追加 (SEO改善) |

### Lighthouse 目標スコア

| カテゴリ | 目標 |
|---|---|
| Performance | ≥ 90 |
| Accessibility | ≥ 95 |
| Best Practices | ≥ 95 |
| SEO | ≥ 90 |
| LCP | ≤ 2.5s |
| CLS | ≤ 0.1 |
| TBT | ≤ 300ms |

### 技術詳細

**Route-based code splitting**: `React.lazy()` により初期 JS バンドルを大幅削減。ユーザーが訪問したページのみ動的にロード。

**manualChunks**: Vite rollup で vendor ライブラリを独立 chunk に分割 → ブラウザキャッシュ効率向上。

**PageFallback**: CLS 防止のため最小スピナーのみの fallback コンポーネント。

### テスト

- Vitest: `App.test.tsx` は `vi.mock()` でページをモック済み → lazy 変換に対応
- Lighthouse CI: `lighthouse-ci.yml` workflow で自動計測
- E2E: Playwright による smoke テスト継続

### 影響範囲

- フロントエンド bundle 構造のみ変更 (backend 影響なし)
- API / ルーティング動作は変更なし

Closes #126

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * ルーティングの遅延読み込み（React.lazy）と読み込み中のフォールバックを導入し、初期表示体感を改善しました。

* **ドキュメント**
  * ページの meta description を追加し、検索結果や共有プレビューの表示を改善しました。

* **Chores**
  * バンドル分割を最適化（ベンダーチャンク化）し読み込み効率を向上しました。
  * Lighthouse の品質目標を厳格化し、スコア/コアウェブバイタル閾値を引き上げました。
  * E2E 実行をビルド→プレビューへ切替えしタイムアウトを延長しました。

* **Tests**
  * テストを非同期検証へ更新し、E2E ヘルパーでページの main 要素待機を追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->