### PR TITLE
feat(phase5e3): Tailwind ブランドカラー token 整備 (Closes #134)

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -3,6 +3,46 @@
 @tailwind utilities;
 
 @layer base {
+  :root {
+    /* Brand colors — canonical from docs/design/ServiceHub-WebUI.html */
+    --brand-90: #0b2545;
+    --brand-80: #13315c;
+    --brand-70: #1b4079;
+    --brand-60: #2458a6;
+    --brand-50: #3b7dd8;
+    --brand-20: #d6e4f5;
+    --brand-10: #eaf2fb;
+
+    /* Safety / Status */
+    --safety-60: #d64a1a;
+    --safety-50: #e76025;
+    --safety-20: #fde3d2;
+    --safety-10: #fff1e8;
+
+    --ok-60:    #0f8b4a;
+    --ok-20:    #d3f0df;
+    --ok-10:    #e6f7ee;
+
+    --warn-60:  #b76200;
+    --warn-20:  #fde6c4;
+    --warn-10:  #fff4e0;
+
+    --err-60:   #c8102e;
+    --err-20:   #ffd4d8;
+    --err-10:   #ffebed;
+
+    --info-60:  #2458a6;
+
+    /* Surface */
+    --bg:      #f4f4f4;
+    --surface: #ffffff;
+    --line:    #e0e0e0;
+    --line-strong: #c6c6c6;
+
+    /* Focus ring */
+    --focus: 0 0 0 2px #ffffff, 0 0 0 4px var(--brand-60);
+  }
+
   body {
     @apply bg-gray-50 text-gray-900 antialiased;
   }

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -5,13 +5,46 @@ export default {
   theme: {
     extend: {
       colors: {
+        // Primary — mapped to canonical brand tokens (docs/design/ServiceHub-WebUI.html)
         primary: {
-          50: "#eff6ff",
-          100: "#dbeafe",
-          500: "#3b82f6",
-          600: "#2563eb",
-          700: "#1d4ed8",
-          900: "#1e3a8a",
+          10:  "var(--brand-10)",
+          20:  "var(--brand-20)",
+          50:  "var(--brand-50)",
+          500: "var(--brand-50)",
+          600: "var(--brand-60)",
+          700: "var(--brand-70)",
+          800: "var(--brand-80)",
+          900: "var(--brand-90)",
+        },
+        brand: {
+          10:  "var(--brand-10)",
+          20:  "var(--brand-20)",
+          50:  "var(--brand-50)",
+          60:  "var(--brand-60)",
+          70:  "var(--brand-70)",
+          80:  "var(--brand-80)",
+          90:  "var(--brand-90)",
+        },
+        safety: {
+          10:  "var(--safety-10)",
+          20:  "var(--safety-20)",
+          50:  "var(--safety-50)",
+          60:  "var(--safety-60)",
+        },
+        ok: {
+          10:  "var(--ok-10)",
+          20:  "var(--ok-20)",
+          60:  "var(--ok-60)",
+        },
+        warn: {
+          10:  "var(--warn-10)",
+          20:  "var(--warn-20)",
+          60:  "var(--warn-60)",
+        },
+        err: {
+          10:  "var(--err-10)",
+          20:  "var(--err-20)",
+          60:  "var(--err-60)",
         },
         construction: {
           orange: "#f97316",


### PR DESCRIPTION
## 変更内容

Issue #134 対応: Tailwind CSS にブランドカラー token を整備し、canonical CSS 変数と接続。

### 主な変更
- `frontend/src/index.css`: `:root` に CSS 変数 (`--brand-*`, `--safety-*`, `--ok-*`, `--warn-*`, `--err-*`, `--info-*`) を追加
- `frontend/tailwind.config.js`: `primary`, `brand`, `safety`, `ok`, `warn`, `err` スケールを CSS 変数にマッピング

### ソース
- `docs/design/ServiceHub-WebUI.html` を正ソースとして参照

## テスト結果
- Lint / Build: pass

## 影響範囲
- フロントエンドの CSS 変数のみ（ロジック変更なし）

## 残課題
- Issue #135 Sidebar カラー統一（次 PR）

Closes #134

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * デザインシステムのカラートークンを統一化しました。ブランド、ステータス、UI表面色を含む包括的なカラーパレットを実装し、ビジュアルの一貫性を向上させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->