### PR TITLE
feat(phase5e5): デザインファイル実装 — IBM Plex フォント + TopBar + CommandPalette (Closes #142)

### DIFF
--- a/frontend/e2e/users-crud.spec.ts
+++ b/frontend/e2e/users-crud.spec.ts
@@ -255,9 +255,10 @@ test.describe("Users CRUD", () => {
   });
 
   test("shows role badges for users", async ({ page }) => {
-    // Use exact match to avoid matching navigation items or email strings containing role names
-    await expect(page.getByText("ADMIN", { exact: true })).toBeVisible();
-    await expect(page.getByText("VIEWER", { exact: true })).toBeVisible();
+    // Scope to main content to avoid matching the sidebar's logged-in user role badge
+    const main = page.locator("main");
+    await expect(main.getByText("ADMIN", { exact: true })).toBeVisible();
+    await expect(main.getByText("VIEWER", { exact: true })).toBeVisible();
   });
 
   // ─── Access control ───────────────────────────────────

--- a/frontend/src/components/layout/Layout.test.tsx
+++ b/frontend/src/components/layout/Layout.test.tsx
@@ -43,25 +43,30 @@ describe("Layout", () => {
 
   it("アプリケーション名が表示される", () => {
     renderLayout();
-    expect(screen.getByText("ServiceHub")).toBeInTheDocument();
+    // "ServiceHub" appears in both sidebar logo and breadcrumb; verify at least one exists
+    expect(screen.getAllByText("ServiceHub").length).toBeGreaterThan(0);
     expect(screen.getByText("工事管理")).toBeInTheDocument();
   });
 
-  it("ヘッダータイトルが表示される", () => {
+  it("サイドバーロゴが表示される", () => {
     renderLayout();
-    expect(screen.getByText("ServiceHub 工事管理プラットフォーム")).toBeInTheDocument();
+    // Sidebar logo text is in <p> elements inside the sidebar
+    const sidebar = screen.getByRole("complementary", { name: "サイドバーナビゲーション" });
+    expect(sidebar).toHaveTextContent("ServiceHub");
+    expect(sidebar).toHaveTextContent("工事管理");
   });
 
   it("ナビゲーション項目が表示される", () => {
     renderLayout();
-    expect(screen.getByText("ダッシュボード")).toBeInTheDocument();
-    expect(screen.getByText("工事案件")).toBeInTheDocument();
-    expect(screen.getByText("日報")).toBeInTheDocument();
-    expect(screen.getByText("安全品質")).toBeInTheDocument();
-    expect(screen.getByText("原価管理")).toBeInTheDocument();
-    expect(screen.getByText("写真管理")).toBeInTheDocument();
-    expect(screen.getByText("ITSM")).toBeInTheDocument();
-    expect(screen.getByText("ナレッジ")).toBeInTheDocument();
+    const nav = screen.getByRole("navigation", { name: "メインナビゲーション" });
+    expect(nav).toHaveTextContent("ダッシュボード");
+    expect(nav).toHaveTextContent("工事案件");
+    expect(nav).toHaveTextContent("日報");
+    expect(nav).toHaveTextContent("安全品質");
+    expect(nav).toHaveTextContent("原価管理");
+    expect(nav).toHaveTextContent("写真管理");
+    expect(nav).toHaveTextContent("ITSM");
+    expect(nav).toHaveTextContent("ナレッジ");
   });
 
   it("ADMINユーザーの場合、ユーザー管理が表示される", () => {
@@ -76,7 +81,8 @@ describe("Layout", () => {
 
   it("ログアウトボタンをクリックすると logout が呼ばれる", () => {
     renderLayout();
-    fireEvent.click(screen.getByText("ログアウト"));
+    // Logout button is icon-only with aria-label
+    fireEvent.click(screen.getByRole("button", { name: "ログアウト" }));
     expect(mockLogout).toHaveBeenCalled();
     expect(mockNavigate).toHaveBeenCalledWith("/login");
   });

--- a/frontend/src/components/layout/Layout.tsx
+++ b/frontend/src/components/layout/Layout.tsx
@@ -1,5 +1,6 @@
 import { Outlet, Link, useNavigate, useLocation } from "react-router-dom";
 import { ErrorBoundary } from "@/components/ui/ErrorBoundary";
+import { CommandPalette } from "@/components/ui/CommandPalette";
 import {
   LayoutDashboard,
   Building2,
@@ -21,8 +22,12 @@ import {
   Newspaper,
   UserCog,
   BookText,
+  Search,
+  Wifi,
+  WifiOff,
+  ChevronRight,
 } from "lucide-react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useAuthStore } from "@/stores/authStore";
 import { useTheme } from "@/contexts/ThemeContext";
 import { useSSE } from "@/hooks/useSSE";
@@ -41,8 +46,27 @@ type NavGroup = {
   items: NavItem[];
 };
 
+const ROUTE_LABELS: Record<string, string> = {
+  "/dashboard":           "ダッシュボード",
+  "/projects":            "工事案件",
+  "/reports":             "日報",
+  "/photos":              "写真管理",
+  "/safety":              "安全品質",
+  "/cost":                "原価管理",
+  "/itsm":                "ITSM",
+  "/knowledge":           "ナレッジ",
+  "/portal":              "社内ポータル",
+  "/notices":             "お知らせ",
+  "/hr":                  "人事・勤怠",
+  "/rules":               "社内規程",
+  "/users":               "ユーザー管理",
+  "/admin/notifications": "通知管理",
+  "/settings":            "設定",
+};
+
 export default function Layout() {
   const [sidebarOpen, setSidebarOpen] = useState(false);
+  const [paletteOpen, setPaletteOpen] = useState(false);
   const [panelOpen, setPanelOpen] = useState(false);
   const { user, logout } = useAuthStore();
   const { theme, toggleTheme } = useTheme();
@@ -54,6 +78,27 @@ export default function Layout() {
     setPanelOpen((prev) => !prev);
     clearUnread();
   };
+
+  // Cmd+K global shortcut
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === "k") {
+        e.preventDefault();
+        setPaletteOpen((prev) => !prev);
+      }
+    };
+    document.addEventListener("keydown", handler);
+    return () => document.removeEventListener("keydown", handler);
+  }, []);
+
+  // Breadcrumb derived from pathname
+  const breadcrumb = (() => {
+    const base = "ServiceHub";
+    const matched = Object.entries(ROUTE_LABELS).find(([path]) =>
+      location.pathname.startsWith(path)
+    );
+    return matched ? [base, matched[1]] : [base];
+  })();
 
   const navGroups: NavGroup[] = [
     {
@@ -109,21 +154,22 @@ export default function Layout() {
         to={to}
         onClick={() => setSidebarOpen(false)}
         className={clsx(
-          "flex items-center gap-3 px-3 py-2 rounded-md text-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-60",
+          "flex items-center gap-3 px-3 rounded-lg text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand-60)]",
+          "min-h-[44px]",
           active
-            ? "bg-brand-10 text-brand-70 font-semibold shadow-[inset_3px_0_0_theme(colors.brand.60)]"
-            : "text-gray-700 font-medium hover:bg-gray-100 hover:text-gray-900",
+            ? "bg-[var(--brand-10)] text-[var(--brand-70)] font-semibold shadow-[inset_3px_0_0_var(--brand-60)]"
+            : "text-gray-700 hover:bg-gray-100 hover:text-gray-900",
         )}
         aria-current={active ? "page" : undefined}
       >
-        <Icon className="w-5 h-5 flex-shrink-0" />
+        <Icon className="w-[18px] h-[18px] flex-shrink-0" />
         <span>{label}</span>
       </Link>
     );
   };
 
   return (
-    <div className="flex h-screen bg-gray-50 dark:bg-gray-950">
+    <div className="flex h-screen bg-gray-50">
       {/* Notification panel */}
       <NotificationPanel
         open={panelOpen}
@@ -131,6 +177,9 @@ export default function Layout() {
         onClose={() => setPanelOpen(false)}
         onClearAll={() => { clearNotifications(); setPanelOpen(false); }}
       />
+
+      {/* Command Palette */}
+      <CommandPalette open={paletteOpen} onClose={() => setPaletteOpen(false)} />
 
       {/* Mobile overlay */}
       {sidebarOpen && (
@@ -150,8 +199,8 @@ export default function Layout() {
         )}
       >
         {/* Logo */}
-        <div className="flex items-center gap-3 px-5 h-16 border-b border-gray-200 dark:border-gray-700">
-          <div className="w-9 h-9 rounded-lg bg-gradient-to-br from-brand-50 to-construction-orange flex items-center justify-center flex-shrink-0">
+        <div className="flex items-center gap-3 px-4 h-16 border-b border-gray-200 dark:border-gray-700">
+          <div className="flex items-center justify-center w-9 h-9 rounded-lg bg-gradient-to-br from-[var(--brand-50)] to-[#f97316] flex-shrink-0">
             <HardHat className="w-5 h-5 text-white" aria-hidden="true" />
           </div>
           <div>
@@ -163,7 +212,10 @@ export default function Layout() {
         <nav id="sidebar-nav" aria-label="メインナビゲーション" className="flex-1 px-3 py-4 overflow-y-auto">
           {navGroups.map((group, gi) => (
             <div key={group.label} className={gi > 0 ? "mt-6" : ""}>
-              <div className="px-3 mb-2 text-xs font-semibold uppercase tracking-widest text-gray-400 dark:text-gray-500">
+              <div
+                className="px-3 mb-2 text-xs font-semibold uppercase tracking-widest text-gray-400 dark:text-gray-500"
+                style={{ letterSpacing: "0.14em" }}
+              >
                 {group.label}
               </div>
               <div className="space-y-0.5">
@@ -175,28 +227,37 @@ export default function Layout() {
           ))}
         </nav>
 
-        {/* User / Logout */}
+        {/* User area */}
         <div className="px-4 py-4 border-t border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800">
-          <div className="px-2 py-1 text-xs text-gray-500 dark:text-gray-400 truncate mb-1">
-            {user?.full_name ?? user?.email}
-            <span className="ml-1 text-gray-400 dark:text-gray-500">({user?.role})</span>
+          <div className="flex items-center gap-3">
+            <div className="w-9 h-9 rounded-full bg-[var(--brand-60)] text-white flex items-center justify-center text-xs font-bold flex-shrink-0">
+              {(user?.full_name ?? user?.email ?? "?").slice(0, 2)}
+            </div>
+            <div className="flex-1 min-w-0">
+              <div className="text-sm font-semibold text-gray-900 dark:text-white truncate">
+                {user?.full_name ?? user?.email}
+              </div>
+              <div className="text-xs text-gray-500 dark:text-gray-400">{user?.role}</div>
+            </div>
+            <button
+              onClick={handleLogout}
+              aria-label="ログアウト"
+              className="w-[44px] h-[44px] flex items-center justify-center rounded-lg text-gray-500 dark:text-gray-300 hover:bg-white dark:hover:bg-gray-700 hover:text-gray-900 dark:hover:text-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand-60)]"
+            >
+              <LogOut className="w-4 h-4" aria-hidden="true" />
+            </button>
           </div>
-          <button
-            onClick={handleLogout}
-            className="flex items-center gap-3 w-full px-3 py-2 rounded-md text-sm text-gray-600 dark:text-gray-300 hover:bg-white dark:hover:bg-gray-700 hover:text-gray-900 dark:hover:text-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-60"
-          >
-            <LogOut className="w-4 h-4" aria-hidden="true" />
-            ログアウト
-          </button>
         </div>
       </aside>
 
       {/* Main content */}
       <div className="flex flex-col flex-1 lg:ml-64 min-w-0">
-        {/* Header */}
-        <header className="h-16 bg-white dark:bg-gray-900 border-b border-gray-200 dark:border-gray-700 flex items-center px-4 gap-4 flex-shrink-0">
+        {/* TopBar */}
+        <header className="sticky top-0 z-10 h-16 border-b border-gray-200 flex items-center px-8 gap-5 flex-shrink-0"
+                style={{ background: "rgba(255,255,255,0.92)", backdropFilter: "blur(10px)" }}>
+          {/* Mobile menu toggle */}
           <button
-            className="lg:hidden p-2 rounded-md text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500"
+            className="lg:hidden p-2 rounded-md text-gray-500 hover:bg-gray-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand-60)]"
             onClick={() => setSidebarOpen(!sidebarOpen)}
             aria-label={sidebarOpen ? "メニューを閉じる" : "メニューを開く"}
             aria-expanded={sidebarOpen}
@@ -204,21 +265,69 @@ export default function Layout() {
           >
             {sidebarOpen ? <X className="w-5 h-5" aria-hidden="true" /> : <Menu className="w-5 h-5" aria-hidden="true" />}
           </button>
-          <h1 className="text-lg font-semibold text-gray-800 dark:text-gray-100 flex-1">
-            ServiceHub 工事管理プラットフォーム
-          </h1>
+
+          {/* Breadcrumb */}
+          <nav aria-label="パンくずリスト" className="flex-1 min-w-0">
+            <ol className="flex items-center gap-2 text-sm">
+              {breadcrumb.map((b, i) => (
+                <li key={i} className="flex items-center gap-2">
+                  <span className={clsx(
+                    i === breadcrumb.length - 1
+                      ? "font-semibold text-gray-900"
+                      : "text-gray-500 font-normal",
+                  )}
+                  {...(i === breadcrumb.length - 1 ? { "aria-current": "page" } : {})}>
+                    {b}
+                  </span>
+                  {i < breadcrumb.length - 1 && (
+                    <ChevronRight className="w-3.5 h-3.5 text-gray-400" aria-hidden="true" />
+                  )}
+                </li>
+              ))}
+            </ol>
+          </nav>
+
+          {/* Cmd+K search trigger */}
+          <button
+            onClick={() => setPaletteOpen(true)}
+            aria-label="グローバル検索を開く (⌘K)"
+            data-testid="search-trigger"
+            className="hidden sm:flex items-center gap-2.5 h-10 px-3.5 bg-gray-100 border border-gray-200 rounded-lg text-gray-600 text-sm min-w-[200px] hover:bg-gray-200 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand-60)]"
+          >
+            <Search className="w-4 h-4 flex-shrink-0" />
+            <span className="flex-1 text-left">横断検索 ...</span>
+            <kbd className="font-mono text-xs px-1.5 py-0.5 bg-white rounded border border-gray-200 text-gray-500">⌘K</kbd>
+          </button>
+
+          {/* Online indicator — aria-live only, no role=status to avoid E2E strict mode violation */}
+          <div
+            aria-live="polite"
+            aria-label={connected ? "オンライン" : "オフライン"}
+            className="hidden md:flex items-center gap-2 px-3 py-1.5 rounded-full text-xs font-semibold"
+            style={{
+              background: connected ? "var(--ok-10)" : "var(--warn-10)",
+              color:      connected ? "var(--ok-60)" : "var(--warn-60)",
+            }}
+          >
+            {connected
+              ? <Wifi className="w-3.5 h-3.5" aria-hidden="true" />
+              : <WifiOff className="w-3.5 h-3.5" aria-hidden="true" />}
+            {connected ? "オンライン" : "オフライン"}
+          </div>
+
           {/* Notification badge */}
           <NotificationBadge
             count={unreadCount}
             connected={connected}
             onClick={handleBadgeClick}
           />
+
           {/* Theme toggle */}
           <button
             onClick={toggleTheme}
             aria-label={theme === "dark" ? "ライトモードに切り替え" : "ダークモードに切り替え"}
             data-testid="theme-toggle"
-            className="p-2 rounded-md text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 transition-colors"
+            className="p-2 rounded-lg text-gray-500 hover:bg-gray-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand-60)] transition-colors"
           >
             {theme === "dark" ? (
               <Sun className="w-5 h-5" aria-hidden="true" />

--- a/frontend/src/components/layout/Layout.tsx
+++ b/frontend/src/components/layout/Layout.tsx
@@ -347,3 +347,4 @@ export default function Layout() {
     </div>
   );
 }
+

--- a/frontend/src/components/ui/CommandPalette.tsx
+++ b/frontend/src/components/ui/CommandPalette.tsx
@@ -1,0 +1,168 @@
+import { useEffect, useRef, useMemo, useState } from "react";
+import { createPortal } from "react-dom";
+import { useNavigate } from "react-router-dom";
+import { Search, ChevronRight, Building2, AlertCircle } from "lucide-react";
+
+type NavItem = { type: "nav"; label: string; target: string; kw: string };
+type ProjectItem = { type: "project"; label: string; sub: string; target: string; kw: string };
+type IncidentItem = { type: "incident"; label: string; sub: string; target: string; kw: string };
+type Item = NavItem | ProjectItem | IncidentItem;
+
+const BASE_ITEMS: Item[] = [
+  { type: "nav", label: "ダッシュボード",   target: "/dashboard",  kw: "dashboard ホーム 概要" },
+  { type: "nav", label: "工事案件一覧",     target: "/projects",   kw: "案件 プロジェクト 工事" },
+  { type: "nav", label: "日報",             target: "/reports",    kw: "日報 daily" },
+  { type: "nav", label: "写真管理",         target: "/photos",     kw: "写真 フォト" },
+  { type: "nav", label: "安全品質",         target: "/safety",     kw: "安全 KY 危険予知 品質" },
+  { type: "nav", label: "原価管理",         target: "/cost",       kw: "原価 コスト 予実" },
+  { type: "nav", label: "ITSM",            target: "/itsm",       kw: "インシデント 変更 ITSM" },
+  { type: "nav", label: "ナレッジ",         target: "/knowledge",  kw: "ナレッジ wiki" },
+  { type: "nav", label: "社内ポータル",     target: "/portal",     kw: "ポータル 社内" },
+  { type: "nav", label: "お知らせ",         target: "/notices",    kw: "お知らせ 掲示板" },
+  { type: "nav", label: "人事・勤怠",       target: "/hr",         kw: "人事 勤怠 HR" },
+  { type: "nav", label: "社内規程",         target: "/rules",      kw: "規程 手続き" },
+  { type: "nav", label: "設定",             target: "/settings",   kw: "設定 プロフィール" },
+];
+
+const TYPE_LABEL: Record<Item["type"], string> = {
+  nav: "ページ",
+  project: "案件",
+  incident: "障害",
+};
+
+interface CommandPaletteProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+export function CommandPalette({ open, onClose }: CommandPaletteProps) {
+  const [q, setQ] = useState("");
+  const inputRef = useRef<HTMLInputElement>(null);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (open) {
+      setQ("");
+      setTimeout(() => inputRef.current?.focus(), 20);
+    }
+  }, [open]);
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === "k") {
+        e.preventDefault();
+        if (!open) return;
+        onClose();
+      }
+      if (e.key === "Escape" && open) onClose();
+    };
+    document.addEventListener("keydown", handler);
+    return () => document.removeEventListener("keydown", handler);
+  }, [open, onClose]);
+
+  const items = useMemo(() => {
+    if (!q) return BASE_ITEMS.slice(0, 8);
+    return BASE_ITEMS.filter((it) =>
+      (it.kw + " " + it.label).toLowerCase().includes(q.toLowerCase())
+    ).slice(0, 10);
+  }, [q]);
+
+  if (!open) return null;
+
+  const handleSelect = (target: string) => {
+    navigate(target);
+    onClose();
+  };
+
+  const iconFor = (type: Item["type"]) => {
+    if (type === "project") return <Building2 size={16} />;
+    if (type === "incident") return <AlertCircle size={16} />;
+    return <ChevronRight size={16} />;
+  };
+
+  const bgFor = (type: Item["type"]) => {
+    if (type === "project") return { bg: "var(--ok-10)",   fg: "var(--ok-60)" };
+    if (type === "incident") return { bg: "var(--warn-10)", fg: "var(--warn-60)" };
+    return { bg: "var(--brand-10)", fg: "var(--brand-60)" };
+  };
+
+  return createPortal(
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="グローバル検索"
+      data-testid="command-palette"
+      className="fixed inset-0 z-[1000] flex items-start justify-center pt-[10vh]"
+      style={{ background: "rgba(15,23,42,0.55)" }}
+      onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
+    >
+      <div
+        className="w-full max-w-xl rounded-2xl overflow-hidden bg-white"
+        style={{ boxShadow: "var(--e3)" }}
+      >
+        {/* Input */}
+        <div className="flex items-center gap-3 px-5 py-3.5 border-b border-gray-200">
+          <Search size={20} className="text-gray-500 flex-shrink-0" />
+          <input
+            ref={inputRef}
+            value={q}
+            onChange={(e) => setQ(e.target.value)}
+            placeholder="案件・日報・ナレッジ・コマンドを検索..."
+            aria-label="グローバル検索"
+            className="flex-1 border-0 outline-none bg-transparent text-base text-gray-900 placeholder:text-gray-400"
+            onKeyDown={(e) => e.key === "Escape" && onClose()}
+          />
+          <kbd className="font-mono text-xs px-2 py-0.5 rounded bg-gray-100 border border-gray-200 text-gray-600">
+            ESC
+          </kbd>
+        </div>
+
+        {/* Results */}
+        <div className="max-h-[420px] overflow-y-auto p-2">
+          {items.length === 0 && (
+            <div className="py-8 text-center text-gray-500 text-sm">結果なし</div>
+          )}
+          {items.map((it, i) => {
+            const { bg, fg } = bgFor(it.type);
+            return (
+              <button
+                key={i}
+                onClick={() => handleSelect(it.target)}
+                className="flex w-full items-center gap-3 px-3.5 py-3 rounded-lg text-left transition-colors hover:bg-[var(--brand-10)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand-60)]"
+              >
+                <span
+                  className="w-8 h-8 rounded flex items-center justify-center flex-shrink-0"
+                  style={{ background: bg, color: fg }}
+                >
+                  {iconFor(it.type)}
+                </span>
+                <div className="flex-1 min-w-0">
+                  <div className="font-medium text-sm text-gray-900 truncate">{it.label}</div>
+                  {"sub" in it && it.sub && (
+                    <div className="text-xs text-gray-500 font-mono mt-0.5">{it.sub}</div>
+                  )}
+                </div>
+                <span className="text-xs text-gray-400 uppercase tracking-wide">
+                  {TYPE_LABEL[it.type]}
+                </span>
+              </button>
+            );
+          })}
+        </div>
+
+        {/* Footer */}
+        <div className="flex justify-end gap-4 px-5 py-2.5 border-t border-gray-200 text-xs text-gray-500">
+          <span>
+            <kbd className="font-mono px-1.5 py-0.5 bg-gray-100 rounded border border-gray-200">↵</kbd>
+            {" "}で移動
+          </span>
+          <span>
+            <kbd className="font-mono px-1.5 py-0.5 bg-gray-100 rounded border border-gray-200">⌘K</kbd>
+            {" "}で開閉
+          </span>
+        </div>
+      </div>
+    </div>,
+    document.body
+  );
+}

--- a/frontend/src/components/ui/CommandPalette.tsx
+++ b/frontend/src/components/ui/CommandPalette.tsx
@@ -39,13 +39,18 @@ export function CommandPalette({ open, onClose }: CommandPaletteProps) {
   const [q, setQ] = useState("");
   const inputRef = useRef<HTMLInputElement>(null);
   const navigate = useNavigate();
+  const prevOpen = useRef(false);
 
+  // Focus input when palette opens; reset query on next render after close
   useEffect(() => {
-    if (open) {
-      setQ("");
+    if (open && !prevOpen.current) {
       setTimeout(() => inputRef.current?.focus(), 20);
     }
+    prevOpen.current = open;
   }, [open]);
+
+  // Sync q reset: happens outside the effect body to avoid cascading-render lint rule
+  if (!open && q !== "") setQ("");
 
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,9 +1,47 @@
+@import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500;600&family=Noto+Sans+JP:wght@400;500;600;700&display=swap');
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
 
 @layer base {
   :root {
+    /* Typography */
+    --font-sans: 'IBM Plex Sans', 'Noto Sans JP', system-ui, sans-serif;
+    --font-mono: 'IBM Plex Mono', ui-monospace, monospace;
+
+    /* Type scale */
+    --fs-12: 0.75rem;
+    --fs-14: 0.875rem;
+    --fs-16: 1rem;
+    --fs-18: 1.125rem;
+    --fs-20: 1.25rem;
+    --fs-24: 1.5rem;
+    --fs-28: 1.75rem;
+    --fs-32: 2rem;
+
+    /* Spacing / radius */
+    --touch: 44px;
+    --r-sm: 4px;
+    --r-md: 8px;
+    --r-lg: 12px;
+    --r-xl: 16px;
+    --r-pill: 9999px;
+
+    /* Elevation */
+    --e1: 0 1px 3px rgba(0,0,0,0.08);
+    --e2: 0 4px 16px rgba(0,0,0,0.10);
+    --e3: 0 8px 40px rgba(0,0,0,0.14);
+
+    /* Gray scale */
+    --gray-10: #f4f4f4;
+    --gray-20: #e0e0e0;
+    --gray-40: #a8a8a8;
+    --gray-50: #8d8d8d;
+    --gray-60: #6f6f6f;
+    --gray-70: #525252;
+    --gray-80: #393939;
+    --gray-100: #161616;
     /* Brand colors — canonical from docs/design/ServiceHub-WebUI.html */
     --brand-90: #0b2545;
     --brand-80: #13315c;
@@ -44,7 +82,12 @@
   }
 
   body {
+    font-family: var(--font-sans);
     @apply bg-gray-50 text-gray-900 antialiased;
+  }
+
+  code, kbd, pre, .font-mono {
+    font-family: var(--font-mono);
   }
 }
 


### PR DESCRIPTION
## 変更内容

`docs/design/ServiceHub-WebUI.html` の canonical デザインを実装。

### 追加機能
- **IBM Plex Sans/Mono フォント** — index.css で Google Fonts インポート
- **TopBar** — sticky + backdrop-blur, パンくずリスト, Cmd+K 検索トリガー, オンライン状態インジケーター
- **CommandPalette** — Cmd+K グローバル検索, 13ナビゲーション項目, ESC/Enter ショートカット
- **Sidebar canonical** — 白背景, brand color アクティブ状態 (inset shadow), グループ別 nav

### CI修正 (同PR内)
- ESLint `react-hooks/set-state-in-effect` 修正 (CommandPalette.tsx)
- Vitest 4テスト修正 (Layout.test.tsx — 新UIセレクター対応)
- E2E strict mode 修正 (Layout.tsx — `role="status"` 除去)

## テスト結果

- Lint: ✅ 通過 (ローカル確認済み)
- Vitest: テスト更新済み (CI確認待ち)
- E2E: strict mode 修正済み (CI確認待ち)

## 影響範囲

- `frontend/src/index.css` — フォント追加
- `frontend/src/components/layout/Layout.tsx` — TopBar + CommandPalette統合
- `frontend/src/components/ui/CommandPalette.tsx` — 新規追加
- `frontend/src/components/layout/Layout.test.tsx` — テスト更新

## 残課題

なし

Closes #142

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * コマンドパレット機能を追加（Cmd/Ctrl + Kで検索・ナビゲーション可能）
  * パンくずナビゲーションをヘッダーに追加
  * 接続状態を表示するオンライン/オフラインインジケーターを追加
  * ユーザーエリアにアバター表示とヘッダー検索ボタンを追加

* **スタイル**
  * ヘッダーを粘着型に変更し、半透明デザインを適用
  * 新しいフォント体系（IBM Plex Sans、Noto Sans JP）を導入
  * ログアウトボタンをアイコン形式に統一

<!-- end of auto-generated comment: release notes by coderabbit.ai -->