### PR TITLE
chore(phase5-sync): state.json + README を Phase 5 完全完了に同期

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,9 +106,9 @@ graph TB
 | 指標 | 値 |
 | :--- | :--- |
 | 🧪 Backend テスト | **316 件**（pytest / coverage **95%** / Phase 5c AuthService+TemplateRenderer +23 件 / 2 モジュール 100%） |
-| 🧪 Frontend テスト | **270 件**（vitest / 42 テストファイル / coverage **88%** / Phase 3c ThemeContext +7） |
+| 🧪 Frontend テスト | **294 件**（vitest / 44 テストファイル / coverage **88%** / Phase 3c ThemeContext +7 / Phase 5e-3/5e-4/5e-5 実測 +24） |
 | 🎭 E2E テスト | **206 件**（Playwright / 28 テストファイル / Phase 4c 通知バッジ・パネル +11 +ダークモード+5 / Phase 5e-1 社内 4 ページ smoke +4） |
-| 📊 総テスト数 | **792 件**（Backend + Frontend + E2E） |
+| 📊 総テスト数 | **816 件**（Backend + Frontend + E2E） |
 | 🖥️ フロントエンドページ | **17 ページ**（Phase 5e-1 社内グループ新設: Portal / Notices / HR / Rules +4） |
 | 🧩 共通 UI コンポーネント | **14 種**（Badge / Button / Card / ErrorBanner / ErrorBoundary / ErrorText / FormField / Modal / NotificationBadge / NotificationPanel / Pagination / Skeleton / StatCard / Table） |
 | 🎨 共通 UI 適用率 | **12/12 既存ページ**（全ページ統一完了 / Phase 5e-1 新設 4 ページは fixture ベースの reference 実装） |
@@ -122,7 +122,7 @@ graph TB
 | ✅ CI チェック数 | **15 チェック**（ruff / mypy / pytest / bandit / vitest / build / E2E / dependency / type-check x2 / test-coverage x2 / lint-build x2 + Lighthouse CI） |
 | 📊 Prometheus メトリクス | **有効**（`/metrics` エンドポイント / 全ルート RED メトリクス自動計測） |
 | ⚡ Web Vitals | **有効**（LCP / INP / CLS / TTFB / FCP / web-vitals v5） |
-| 🔒 STABLE 判定 | **達成**（main CI 全 success / Phase 3a PR#110 / 3b PR#111 / 3c PR#113 / 3d PR#115 / Phase 4a PR#119 / 4b PR#121 / 4c PR#123 / Phase 5a PR#129 Docker / Phase 5c PR#130 coverage 95% / Phase 5e-1 PR#136 社内 4 ページ 全 merge 済み） |
+| 🔒 STABLE 判定 | **達成**（main CI 全 success / Phase 3a PR#110 / 3b PR#111 / 3c PR#113 / 3d PR#115 / Phase 4a PR#119 / 4b PR#121 / 4c PR#123 / Phase 5a PR#129 Docker / Phase 5b PR#139 Lighthouse / Phase 5c PR#130 coverage 95% / Phase 5d PR#148 codegen 同期 / Phase 5e-1 PR#136 社内 4 ページ / 5e-2 PR#138 サイドバー 4 グループ / 5e-3 PR#140 Tailwind tokens / 5e-4 PR#141 Sidebar 配色 / 5e-5 PR#144 WebUI デザインシステム 全 merge 済み — **Phase 5 完全完了**） |
 
 ### 🏗️ Backend アーキテクチャ
 
@@ -156,7 +156,7 @@ graph LR
 
 ```mermaid
 graph TD
-    subgraph Pages["📄 ページ (12)"]
+    subgraph Pages["📄 ページ (17)"]
         LP["🔐 LoginPage"]
         DP["📊 DashboardPage"]
         PP["🗂️ ProjectsPage"]

--- a/state.json
+++ b/state.json
@@ -1,9 +1,9 @@
 {
-  "phase": "Phase 5e-2 merged (PR#138/1fe8787) → Phase 5b Lighthouse #126 着手",
-  "loop": "Day18-Phase5b-Lighthouse",
-  "loop_count": 135,
+  "phase": "Phase 5 完全完了 (5a/5b/5c/5d/5e-1〜5e-5 all merged) → Phase 6 移行準備",
+  "loop": "Day23-Phase5-Complete-Sync",
+  "loop_count": 136,
   "status": "active",
-  "last_updated": "2026-04-18T18:10:00+09:00",
+  "last_updated": "2026-04-23T20:45:00+09:00",
   "execution": {
     "start_time": "2026-04-18T13:57:32+09:00",
     "max_duration_minutes": 300,
@@ -37,13 +37,11 @@
   },
   "priorities": {
     "high": [
-      "Issue #133 サイドバー 4 グループ化 (業務 / 運用 / 社内 / 管理)",
-      "Issue #126 Phase 5b: Lighthouse スコア改善 (LCP/CLS/INP)"
+      "Phase 6 移行判断 (5 月リリース準備に向けた scope 固定)"
     ],
     "medium": [
-      "Issue #134 Tailwind トークン統一 (brand-10..90 / safety / warn)",
-      "Issue #128 Phase 5d: OpenAPI codegen 更新 (Frontend 型同期)",
-      "Issue #135 サイドバー brand カラー (デジタル庁準拠)"
+      "Issue #146 Phase 6a Backend coverage 90% (現状 95% 既達だが追跡継続)",
+      "Issue #147 Phase 6c E2E シナリオ追加 (Photos/Safety/Cost)"
     ],
     "low": [
       "Playwright SIGTRAP 環境調査 (Phase 5e-1 E2E spec 実行不可)",
@@ -58,10 +56,11 @@
   },
   "metrics": {
     "backend_tests": 316,
-    "frontend_tests": 270,
+    "frontend_tests": 294,
+    "frontend_tests_note": "Phase 5e-3/5e-4/5e-5 追加分込みで実測 294 (旧記録 270 から +24)",
     "e2e_tests": 206,
     "e2e_tests_note": "Phase 5e-1 +4 (spec コミット済 / ローカル SIGTRAP で実行不可・環境要調査)",
-    "total_tests": 792,
+    "total_tests": 816,
     "frontend_pages": 17,
     "api_endpoints": 53,
     "backend_coverage": 95,
@@ -88,9 +87,27 @@
       ]
     },
     "phase_5b_lighthouse": {
-      "status": "planned",
+      "status": "merged",
+      "pr": "#139",
       "issue": "#126",
-      "priority": "P2"
+      "merged_at": "2026-04-18T08:52:15Z",
+      "merge_commit": "c7c8ac2",
+      "scope": "route-level code splitting (React.lazy + Suspense) + vite manualChunks で bundle 分割",
+      "achievements": {
+        "split_strategy": "vendor-react / vendor-query / vendor-charts / vendor-forms / vendor-icons",
+        "fallback": "PageFallback (最小スピナーで CLS 抑制)",
+        "seo": "index.html meta description 追加"
+      },
+      "lighthouse_targets": {
+        "performance": 90,
+        "accessibility": 95,
+        "best_practices": 95,
+        "seo": 90,
+        "lcp_sec": 2.5,
+        "cls": 0.1,
+        "tbt_ms": 300
+      },
+      "ci_result": "Lighthouse Audit PASS (2m11s)"
     },
     "phase_5c_coverage": {
       "status": "merged",
@@ -109,9 +126,20 @@
       }
     },
     "phase_5d_codegen": {
-      "status": "planned",
+      "status": "merged",
       "issue": "#128",
-      "priority": "P3"
+      "merge_commit_primary": "62d895b",
+      "merge_commit_resync": "3808ce2",
+      "resync_pr": "#148",
+      "merged_at_primary": "2026-04-18T10:04:00Z",
+      "merged_at_resync": "2026-04-23T11:39:29Z",
+      "scope": "OpenAPI spec → openapi-typescript 再生成。backend の LogoutRequest / jti invalidation / 422 response / Notification/Photo/Safety/Cost endpoint 拡充を frontend 型に反映。",
+      "files": [
+        "frontend/src/generated/openapi.json (+1684)",
+        "frontend/src/generated/api-types.ts (+698)",
+        "frontend/src/generated/index.ts (+6, 62d895b のみ)"
+      ],
+      "note": "PR #148 は既存 62d895b と同内容 re-apply (no-op diff) だったが state.json sync の受け皿として機能"
     },
     "phase_5e1_internal_pages": {
       "status": "merged",
@@ -142,6 +170,38 @@
       "branch": "feat/phase5e2-sidebar-groups (deleted)",
       "scope": "Layout.tsx flat navItems → 4-group navGroups (業務/運用/社内/管理)",
       "ci_result": "全10チェック PASS"
+    },
+    "phase_5e3_tailwind_tokens": {
+      "status": "merged",
+      "pr": "#140",
+      "issue": "#134",
+      "merged_at": "2026-04-18T08:57:42Z",
+      "merge_commit": "7241af7",
+      "scope": "Tailwind ブランドカラー token 整備 — canonical CSS 変数 (brand-10..90 / safety / warn) 反映"
+    },
+    "phase_5e4_sidebar_colors": {
+      "status": "merged",
+      "pr": "#141",
+      "issue": "#135",
+      "merged_at": "2026-04-18T09:10:05Z",
+      "merge_commit": "952adac",
+      "scope": "Sidebar 配色統一 — canonical white bg 準拠 (デジタル庁準拠)"
+    },
+    "phase_5e5_webui_design_system": {
+      "status": "merged",
+      "pr": "#144",
+      "issue": "#142",
+      "merged_at": "2026-04-18T09:56:32Z",
+      "merge_commit": "cda0f1a",
+      "scope": "ServiceHub WebUI デザインシステム実装 — IBM Plex フォント + TopBar + CommandPalette + Sidebar 刷新"
+    },
+    "phase_5d_post_resync": {
+      "status": "merged",
+      "pr": "#148",
+      "merged_at": "2026-04-23T11:39:29Z",
+      "merge_commit": "3808ce2",
+      "scope": "Phase 5d codegen 再同期 + state.json 5e-2 反映 + cron session 記録 (本セッション)",
+      "note": "2026-04-23 cron 再開時にローカル main が origin より古く、未コミット差分を片付ける形で作業した結果"
     }
   },
   "phase4_status": {
@@ -159,19 +219,26 @@
     }
   },
   "resume_point": {
-    "action": "Issue #126 Phase 5b Lighthouse スコア改善 着手 (LCP/CLS/INP)",
-    "branch": "feat/phase5b-lighthouse (worktree 新規作成)",
-    "next_phase": "#126 Lighthouse → #134 Tailwind token → #135 Sidebar brand → #128 codegen"
+    "action": "Phase 6 移行判断 + Open Issue (#146 Backend coverage / #147 E2E) 精査",
+    "branch": "(次セッションで新規作成)",
+    "next_phase": "Phase 6a (#146 coverage) or Phase 6c (#147 E2E) の着手順を CTO 判断で決定",
+    "phase5_closure_note": "2026-04-23 の PR #148 merge で state.json / README を Phase 5 完全完了に同期済み"
   },
   "current_sprint": {
-    "phase": "Sprint 6 Phase 5",
+    "phase": "Sprint 6 Phase 5 完了 → Sprint 7 Phase 6 開始前",
     "completed_prs_phase5": [
-      "PR#129",
-      "PR#130",
-      "PR#136",
-      "PR#138"
+      "PR#129 (5a Docker)",
+      "PR#130 (5c Coverage)",
+      "PR#136 (5e-1 Pages)",
+      "PR#138 (5e-2 Sidebar groups)",
+      "PR#139 (5b Lighthouse)",
+      "PR#140 (5e-3 Tailwind tokens)",
+      "PR#141 (5e-4 Sidebar colors)",
+      "PR#144 (5e-5 WebUI design system)",
+      "62d895b (5d codegen primary)",
+      "PR#148 (5d codegen re-sync + state sync)"
     ],
     "in_review_phase5": [],
-    "next": "Issue #126 Lighthouse / #134 Tailwind token / #135 Sidebar brand / #128 codegen"
+    "next": "Phase 6 scope 確定 → Issue #146 / #147 取り組み順を決定"
   }
 }


### PR DESCRIPTION
## Summary

2026-04-23 cron 再開時に発見した **state.json ドリフト** を解消し、Phase 5 完全完了を文書化。

origin/main には既に Phase 5b/5d/5e-3/5e-4/5e-5 が merged されていたが、state.json の phase5_status には Phase 5a/5c/5e-1/5e-2 のみ記録されており、priorities も closed 済の issue を列挙したまま。本 PR で「単一の真実」を実態に一致させる。

## 変更内容

### state.json
| 項目 | 変更 |
|---|---|
| `phase` | "Phase 5 完全完了 → Phase 6 移行準備" |
| `phase_5b_lighthouse` | planned → merged (PR#139/c7c8ac2, route-level code splitting) |
| `phase_5d_codegen` | planned → merged (primary 62d895b + resync PR#148) |
| `phase_5e3_tailwind_tokens` | 新規追加 (PR#140/7241af7, Closes #134) |
| `phase_5e4_sidebar_colors` | 新規追加 (PR#141/952adac, Closes #135) |
| `phase_5e5_webui_design_system` | 新規追加 (PR#144/cda0f1a, Closes #142) |
| `phase_5d_post_resync` | 新規追加 (PR#148/3808ce2, 本セッション) |
| `priorities.high/medium` | closed 済を全除去、Phase 6 移行 + #146/#147 に再編 |
| `metrics.frontend_tests` | 270 → **294** (実測反映) |
| `metrics.total_tests` | 792 → **816** |
| `resume_point` | Phase 6 Open Issue 精査に更新 |
| `current_sprint.completed_prs_phase5` | PR#139/140/141/144/148 + 62d895b を追加 |

### README.md
- **STABLE 判定表**: Phase 5b/5d/5e-2/5e-3/5e-4/5e-5 全 merge を追記、"**Phase 5 完全完了**" 明記
- **Frontend テスト**: 270 → 294 / **総テスト**: 792 → 816
- **フロントエンドアーキテクチャ図**: "📄 ページ (12)" → "(17)" (Phase 5e-1 整合)

## Test plan

- [x] state.json JSON 構文バリデーション (python -m json.tool) PASS
- [ ] Backend CI (ruff/mypy/pytest/bandit/dependency) PASS
- [ ] Frontend CI (lint/build/vitest/E2E/Lighthouse) PASS
- [ ] CodeRabbit レビュー

## 影響範囲

- ドキュメント・state.json のみ変更、コード変更なし
- 次 cron 再開時に最新状態から判断できるようになる (今回の混乱を防止)
- Phase 6 着手前の "Phase 5 完全完了" を外部説明に耐える形で明記

## 残課題

- Phase 6 scope 決定 (Issue #146 Backend coverage / #147 E2E 追加 の取り組み順)
- ローカル 8c928b6 の orphan commit は backup/pre-reset-8c928b6 branch に保全済 (内容は origin に含まれているため delete 可)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>