### PR TITLE
feat(phase6c): cost E2E に集計表示・記録テーブル・エラーパスを追加 (#147)

### DIFF
--- a/frontend/e2e/cost.spec.ts
+++ b/frontend/e2e/cost.spec.ts
@@ -93,18 +93,21 @@ test.describe("Cost Page", () => {
 
     await page.locator("select").first().selectOption("1");
 
-    // 4 summary cards must appear: 予算合計 / 実績合計 / 差異 / 達成率
-    await expect(page.getByText("予算合計")).toBeVisible({ timeout: 10_000 });
-    await expect(page.getByText("実績合計")).toBeVisible();
-    await expect(page.getByText("差異")).toBeVisible();
-    await expect(page.getByText("達成率")).toBeVisible();
+    // Summary card region — scope to the 4-card grid so labels don't collide
+    // with the records table header (which also has "予算"/"実績"/"差異" columns).
+    const summaryCards = page.locator("div.grid.grid-cols-2.lg\\:grid-cols-4").first();
+    await expect(summaryCards).toBeVisible({ timeout: 10_000 });
+    await expect(summaryCards.getByText("予算合計")).toBeVisible();
+    await expect(summaryCards.getByText("実績合計")).toBeVisible();
+    await expect(summaryCards.getByText("差異", { exact: true })).toBeVisible();
+    await expect(summaryCards.getByText("達成率")).toBeVisible();
 
     // Budget total = ¥10,000,000 — match digits robustly across Intl variants
-    await expect(page.getByText(/10,000,000/).first()).toBeVisible();
+    await expect(summaryCards.getByText(/10,000,000/)).toBeVisible();
     // Actual total = ¥9,200,000
-    await expect(page.getByText(/9,200,000/).first()).toBeVisible();
+    await expect(summaryCards.getByText(/9,200,000/)).toBeVisible();
     // Achievement rate = round(9_200_000 / 10_000_000 * 100) = 92%
-    await expect(page.getByText(/^92%$/)).toBeVisible();
+    await expect(summaryCards.getByText(/^92%$/)).toBeVisible();
   });
 
   test("shows records table rows after project selection", async ({ page }) => {

--- a/frontend/e2e/cost.spec.ts
+++ b/frontend/e2e/cost.spec.ts
@@ -1,22 +1,191 @@
-import { test, expect } from '@playwright/test'
-import { loginAndNavigate } from './fixtures/api-mocks'
+import { test, expect } from "@playwright/test";
+import {
+  loginAndNavigate,
+  MOCK_COST_RECORDS,
+  MOCK_PROJECTS,
+} from "./fixtures/api-mocks";
 
-test.describe('Cost Records', () => {
-  test.beforeEach(async ({ page }) => {
-    await loginAndNavigate(page)
-    await page.goto('/cost')
-    await page.waitForURL('**/cost')
-  })
+const SUMMARY_PAYLOAD = {
+  project_id: "1",
+  total_budgeted: 10_000_000,
+  total_actual: 9_200_000,
+  variance: 800_000,
+  by_category: {
+    LABOR: { budgeted: 10_000_000, actual: 9_200_000, variance: 800_000 },
+  },
+};
 
-  test('shows cost page', async ({ page }) => {
-    // CostPage title is "原価管理"
+/** Navigate to /cost with projects, cost-records, and cost-summary mocked. */
+async function setupCostPage(
+  page: import("@playwright/test").Page,
+  options: { records?: typeof MOCK_COST_RECORDS; summary?: typeof SUMMARY_PAYLOAD | null } = {},
+) {
+  const records = options.records ?? MOCK_COST_RECORDS;
+  const summary = options.summary === undefined ? SUMMARY_PAYLOAD : options.summary;
+
+  await loginAndNavigate(page);
+
+  await page.route("**/api/v1/projects**", (route) => {
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        success: true,
+        data: MOCK_PROJECTS,
+        meta: { page: 1, per_page: 100, total: MOCK_PROJECTS.length },
+      }),
+    });
+  });
+
+  await page.route("**/api/v1/projects/1/cost-records**", (route) => {
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        success: true,
+        data: records,
+        meta: { page: 1, per_page: 20, total: records.length, pages: 1 },
+      }),
+    });
+  });
+
+  await page.route("**/api/v1/projects/1/cost-summary**", (route) => {
+    if (summary === null) {
+      route.fulfill({ status: 500, body: "Internal Server Error" });
+      return;
+    }
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ data: summary }),
+    });
+  });
+
+  await page.goto("/cost");
+  await page.waitForURL("**/cost");
+}
+
+test.describe("Cost Page", () => {
+  test("displays page heading", async ({ page }) => {
+    await setupCostPage(page);
     await expect(
-      page.getByText(/原価管理/).first()
-    ).toBeVisible({ timeout: 10_000 })
-  })
+      page.getByRole("heading", { name: /原価管理/ }),
+    ).toBeVisible({ timeout: 10_000 });
+  });
 
-  test('page loads without errors', async ({ page }) => {
-    await expect(page.getByText(/原価管理/).first()).toBeVisible({ timeout: 10_000 })
-    await expect(page.locator('body')).not.toContainText('Error')
-  })
-})
+  test("shows empty state before project is selected", async ({ page }) => {
+    await setupCostPage(page);
+    await expect(
+      page.getByText("プロジェクトを選択してください"),
+    ).toBeVisible({ timeout: 10_000 });
+  });
+
+  test("displays project selector dropdown", async ({ page }) => {
+    await setupCostPage(page);
+    // First <select> on the page is the project selector
+    const selector = page.locator("select").first();
+    await expect(selector).toBeVisible({ timeout: 10_000 });
+    await expect(selector).toContainText("PRJ-001");
+  });
+
+  test("renders cost summary cards after project selection", async ({ page }) => {
+    await setupCostPage(page);
+
+    await page.locator("select").first().selectOption("1");
+
+    // 4 summary cards must appear: 予算合計 / 実績合計 / 差異 / 達成率
+    await expect(page.getByText("予算合計")).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByText("実績合計")).toBeVisible();
+    await expect(page.getByText("差異")).toBeVisible();
+    await expect(page.getByText("達成率")).toBeVisible();
+
+    // Budget total = ¥10,000,000 — match digits robustly across Intl variants
+    await expect(page.getByText(/10,000,000/).first()).toBeVisible();
+    // Actual total = ¥9,200,000
+    await expect(page.getByText(/9,200,000/).first()).toBeVisible();
+    // Achievement rate = round(9_200_000 / 10_000_000 * 100) = 92%
+    await expect(page.getByText(/^92%$/)).toBeVisible();
+  });
+
+  test("shows records table rows after project selection", async ({ page }) => {
+    await setupCostPage(page);
+
+    await page.locator("select").first().selectOption("1");
+
+    // Table header (visible when records exist)
+    await expect(
+      page.getByRole("columnheader", { name: "カテゴリ" }),
+    ).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByRole("columnheader", { name: "予算" })).toBeVisible();
+    await expect(page.getByRole("columnheader", { name: "実績" })).toBeVisible();
+
+    // Record row shows category badge (LABOR → 労務費) and the description
+    await expect(page.getByText("労務費").first()).toBeVisible();
+    await expect(page.getByText("テストコスト")).toBeVisible();
+  });
+
+  test("renders empty records state for projects with no cost records", async ({ page }) => {
+    await setupCostPage(page, { records: [], summary: { ...SUMMARY_PAYLOAD, total_budgeted: 0, total_actual: 0, variance: 0 } });
+
+    await page.locator("select").first().selectOption("1");
+
+    await expect(
+      page.getByText("原価記録がありません"),
+    ).toBeVisible({ timeout: 10_000 });
+  });
+
+  test("opens new cost record modal when button clicked", async ({ page }) => {
+    await setupCostPage(page);
+
+    // The "新規原価記録" button is disabled until a project is selected
+    const newButton = page.getByRole("button", { name: /新規原価記録/ });
+    await expect(newButton).toBeDisabled();
+
+    await page.locator("select").first().selectOption("1");
+    await expect(newButton).toBeEnabled({ timeout: 10_000 });
+    await newButton.click();
+
+    // Modal opens with required form fields
+    await expect(
+      page.getByRole("heading", { name: /新規原価記録作成/ }),
+    ).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByLabel(/日付/)).toBeVisible();
+    await expect(page.getByLabel(/カテゴリ/)).toBeVisible();
+    await expect(page.getByLabel(/予算金額/)).toBeVisible();
+    await expect(page.getByLabel(/実績金額/)).toBeVisible();
+  });
+
+  test("shows error banner when cost-records API fails", async ({ page }) => {
+    await loginAndNavigate(page);
+
+    await page.route("**/api/v1/projects**", (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          success: true,
+          data: MOCK_PROJECTS,
+          meta: { page: 1, per_page: 100, total: MOCK_PROJECTS.length },
+        }),
+      });
+    });
+    // Simulate 500 for cost-records endpoint
+    await page.route("**/api/v1/projects/1/cost-records**", (route) => {
+      route.fulfill({ status: 500, body: "Internal Server Error" });
+    });
+    // Summary still works so only records fail
+    await page.route("**/api/v1/projects/1/cost-summary**", (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ data: SUMMARY_PAYLOAD }),
+      });
+    });
+
+    await page.goto("/cost");
+    await page.waitForURL("**/cost");
+    await page.locator("select").first().selectOption("1");
+
+    await expect(page.getByRole("alert")).toBeVisible({ timeout: 10_000 });
+  });
+});


### PR DESCRIPTION
## 概要

Issue #147 (Phase 6c E2E Photos/Safety/Cost) の **cost 部分** を充足。
従来 22 行 / 2 tests しかなかった `frontend/e2e/cost.spec.ts` を
`photos.spec.ts` パターンに揃えて **8 tests** に拡張した。

## 変更内容

| 項目 | 旧 | 新 |
|---|---|---|
| ファイル行数 | 22 | 211 |
| tests 数 | 2 | **8** (+6) |
| heading 検証 | ✅ | ✅ |
| 集計カード 4 種検証 | ❌ | ✅ **NEW** (予算合計/実績合計/差異/達成率) |
| 記録テーブル列検証 | ❌ | ✅ **NEW** |
| 空状態検証 | ❌ | ✅ **NEW** |
| 新規モーダル起動検証 | ❌ | ✅ **NEW** |
| エラー時 ErrorBanner | ❌ | ✅ **NEW** |

## 実装パターン

- `setupCostPage` helper で `projects` / `cost-records` / `cost-summary` の 3 エンドポイントを一括モック
- `SUMMARY_PAYLOAD`: total_budgeted=10M, total_actual=9.2M → 達成率 92% を算出値で検証
- 既存 `MOCK_COST_RECORDS` fixture (LABOR / 労務費) を流用
- Intl.NumberFormat 表記揺れ耐性のため数字部分 `/10,000,000/` 正規表現マッチ

## テスト結果

- ✅ `npx tsc --noEmit`: PASS (型エラーなし)
- ✅ `npx playwright test --list`: 8 tests 検出
- ⏳ ローカル chromium は SIGTRAP のため実行不可 → CI で検証

## 影響範囲

- frontend/e2e/cost.spec.ts のみ (testsuite 追加のみ、本体コード変更なし)
- 既存 206 tests → 212 tests 相当

## 残課題

- Phase 6c safety.spec.ts / photos.spec.ts は既に充実 (212/200 lines) のため本 PR では触らない
- Phase 6b Integration/Contract tests は別 Issue 起票予定
- Phase 6d Observability / 6e Security hardening も別 Issue 予定

Closes (部分): #147

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **テスト**
  * コストページの機能テストスイートを拡張し、包括的なカバレッジの改善を実施しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->