### PR TITLE
feat(design-v2): ServiceHub-WebUI.html v2 の token + a11y 差分を frontend に反映

### DIFF
--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -57,3 +57,9 @@
 
 - v1.0 (2026-04-18): 初版。4グループ構成、社内ポータル新設、ブルー系ブランドカラー統一
 - v1.1 (2026-04-18): Phase 5e-1 実装反映。社内グループ 4 ページ (Portal/Notices/HR/Rules) 実装完了、対応表を 12 → 16 行に拡張
+- v1.2 (2026-04-24): **v2 デザイン token を frontend に同期**。
+  - `frontend/src/index.css`: gray-30/gray-90 追加、`--fs-42` (2.625rem) 追加、radius を md=6/lg=8/xl=12 に調整
+  - global `*:focus-visible` / `::placeholder` / `.skip-link` を base レイヤに導入 (WCAG 2.2 SC 2.4.7 / 1.4.3 / 2.4.1)
+  - `frontend/index.html`: `<body>` 直下に skip link `<a href="#main-content" class="skip-link">` を配置
+  - `frontend/src/components/layout/Layout.tsx`: `<main>` に `id="main-content"` + `tabIndex={-1}` 付与
+  - 影響範囲: ページマークアップ変更なし (token 更新 + 2要素追加のみ)

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -8,6 +8,7 @@
     <title>ServiceHub 工事管理プラットフォーム</title>
   </head>
   <body>
+    <a href="#main-content" class="skip-link">メインコンテンツへスキップ</a>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/frontend/src/components/layout/Layout.tsx
+++ b/frontend/src/components/layout/Layout.tsx
@@ -337,8 +337,12 @@ export default function Layout() {
           </button>
         </header>
 
-        {/* Page content */}
-        <main className="flex-1 overflow-y-auto p-4 md:p-6">
+        {/* Page content — main-content は skip link (index.html) の飛び先 */}
+        <main
+          id="main-content"
+          tabIndex={-1}
+          className="flex-1 overflow-y-auto p-4 md:p-6 focus:outline-none"
+        >
           <ErrorBoundary>
             <Outlet />
           </ErrorBoundary>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -19,13 +19,14 @@
     --fs-24: 1.5rem;
     --fs-28: 1.75rem;
     --fs-32: 2rem;
+    --fs-42: 2.625rem;
 
     /* Spacing / radius */
     --touch: 44px;
     --r-sm: 4px;
-    --r-md: 8px;
-    --r-lg: 12px;
-    --r-xl: 16px;
+    --r-md: 6px;
+    --r-lg: 8px;
+    --r-xl: 12px;
     --r-pill: 9999px;
 
     /* Elevation */
@@ -33,14 +34,16 @@
     --e2: 0 4px 16px rgba(0,0,0,0.10);
     --e3: 0 8px 40px rgba(0,0,0,0.14);
 
-    /* Gray scale */
+    /* Gray scale — Carbon Gray 100, v2 追加: gray-30 / gray-90 */
     --gray-10: #f4f4f4;
     --gray-20: #e0e0e0;
+    --gray-30: #c6c6c6;
     --gray-40: #a8a8a8;
     --gray-50: #8d8d8d;
     --gray-60: #6f6f6f;
     --gray-70: #525252;
     --gray-80: #393939;
+    --gray-90: #262626;
     --gray-100: #161616;
     /* Brand colors — canonical from docs/design/ServiceHub-WebUI.html */
     --brand-90: #0b2545;
@@ -88,6 +91,38 @@
 
   code, kbd, pre, .font-mono {
     font-family: var(--font-mono);
+  }
+
+  /* v2: global focus-visible — 個別 ring ユーティリティ非適用の DOM にも
+     WCAG 2.2 SC 2.4.7 Focus Visible を保証する safety net */
+  *:focus-visible {
+    outline: 2px solid var(--brand-60);
+    outline-offset: 2px;
+    border-radius: var(--r-sm);
+  }
+
+  /* v2: placeholder のコントラスト確保 (WCAG 1.4.3) */
+  ::placeholder {
+    color: var(--gray-60);
+    opacity: 1;
+  }
+
+  /* v2: WCAG 2.4.1 Skip to main content */
+  .skip-link {
+    position: absolute;
+    top: -100px;
+    left: 16px;
+    background: var(--gray-100);
+    color: #ffffff;
+    padding: 12px 20px;
+    border-radius: var(--r-md);
+    font-weight: 600;
+    z-index: 9999;
+    transition: top 0.15s;
+  }
+  .skip-link:focus {
+    top: 12px;
+    text-decoration: none;
   }
 }
 


### PR DESCRIPTION
## Summary
- `docs/design/ServiceHub-WebUI.html` (v2 改善版 WebUI) の設計 token と WCAG 2.2 a11y 改善を Tailwind + React 側へ移植
- ページマークアップは変更せず、:root token 増補と 2 要素追加のみで全コンポーネントに波及 (Phase 5e-1 で確立した単一源泉パイプライン踏襲)
- Phase 6d Observability (#153) 着手中に割り込みで入ったデザイン同期タスク

## 変更内容

### Token 差分 (`frontend/src/index.css`)
| 項目 | before | after | 目的 |
|---|---|---|---|
| `--gray-30` | 未定義 | `#c6c6c6` | Carbon Gray 100 準拠 |
| `--gray-90` | 未定義 | `#262626` | Carbon Gray 100 準拠 |
| `--fs-42` | 未定義 | `2.625rem` | 最大見出し用 |
| `--r-md` | `8px` | `6px` | 情報密度重視に調整 |
| `--r-lg` | `12px` | `8px` | 情報密度重視に調整 |
| `--r-xl` | `16px` | `12px` | 情報密度重視に調整 |

### A11y 改善
- **global `*:focus-visible`** (base layer): 個別 ring 非適用の DOM にも WCAG 2.2 SC 2.4.7 Focus Visible を保証するセーフティネット
- **`::placeholder`**: WCAG 1.4.3 Contrast (`--gray-60`, `opacity:1`)
- **`.skip-link`**: WCAG 2.4.1 Bypass Blocks — `<body>` 直下に anchor、`<main id="main-content" tabIndex={-1}>` に飛ぶ
- `frontend/index.html`: `<body>` 直下に `<a href=\"#main-content\" class=\"skip-link\">` 配置
- `frontend/src/components/layout/Layout.tsx`: `<main>` に `id=\"main-content\"` + `tabIndex={-1}` + `focus:outline-none` 付与

## テスト結果
- [x] `npm run typecheck` (tsc --noEmit): **PASS** (0 error)
- [x] `npm run build` (tsc && vite build): **PASS** (1683 modules, 6.70s, CSS bundle 42.01 KB)
- [x] Build 成果物に v2 token 反映確認: `--gray-30/90`, `--fs-42`, `.skip-link`, radius 新値、`href=\"#main-content\"` をすべて検出
- [ ] `npm run test` (vitest): **ローカル未実行** — sandbox の vm limit (20GB) による WASM OOM。CI で確認
- [ ] Playwright E2E: CI で確認 (ローカルは SIGTRAP 既知)

## 影響範囲
- ページコンポーネントの書き換えなし (22+ ページ影響なし)
- Tailwind class 追加なし (`tailwind.config.js` の `var(--brand-*)` alias 経由で自動反映)
- CI 影響: lint / typecheck / build / test / E2E すべて通過想定

## 残課題
- Phase 6d Observability (#153) — デザイン同期完了後に再開
- vitest のローカル実行環境問題 (vm limit) は別 Issue で追跡する価値あり (本 PR のスコープ外)

## 参照
- `docs/design/ServiceHub-WebUI.html` (正ソース、commit 08b64ec で v2 更新済)
- `docs/design/README.md` v1.2 更新履歴

🤖 Generated with [Claude Code](https://claude.com/claude-code)