### PR TITLE
feat(phase6d): Observability — health probes + X-Request-ID correlation + structlog (#153)

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -6,14 +6,31 @@ import asyncio
 from contextlib import asynccontextmanager
 
 import structlog
-from fastapi import FastAPI
+import structlog.contextvars
+from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from prometheus_fastapi_instrumentator import Instrumentator
+from sqlalchemy import text
 
 from app.api.v1.router import api_router
 from app.core.config import settings
 from app.core.exceptions import register_exception_handlers
+from app.db.base import engine
 from app.middleware.logging import RequestLoggingMiddleware
+
+# Configure structlog: merge contextvars (request_id etc.) into every log line.
+structlog.configure(
+    processors=[
+        structlog.contextvars.merge_contextvars,
+        structlog.stdlib.add_log_level,
+        structlog.processors.TimeStamper(fmt="iso"),
+        structlog.dev.ConsoleRenderer(),
+    ],
+    wrapper_class=structlog.make_filtering_bound_logger(20),  # INFO
+    context_class=dict,
+    logger_factory=structlog.PrintLoggerFactory(),
+    cache_logger_on_first_use=True,
+)
 
 logger = structlog.get_logger()
 
@@ -108,12 +125,49 @@ Instrumentator().instrument(app).expose(app)
 # ── ヘルスチェック ────────────────────────────────────
 @app.get("/health", tags=["System"])
 async def health_check():
-    """ヘルスチェックエンドポイント"""
+    """後方互換ヘルスチェック (liveness 相当)"""
     return {
         "status": "healthy",
         "service": "servicehub-api",
         "version": settings.APP_VERSION,
     }
+
+
+@app.get("/health/live", tags=["System"])
+async def health_live():
+    """Liveness probe — プロセス生存確認 (DB/Redis 接続不問)。
+
+    コンテナオーケストレータが失敗を検知すると pod を再起動する。
+    DB 障害では kill しないよう DB チェックは含めない。
+    """
+    return {"status": "alive", "service": "servicehub-api"}
+
+
+@app.get("/health/ready", tags=["System"])
+async def health_ready():
+    """Readiness probe — DB + Redis 接続確認。
+
+    失敗 (503) 時はトラフィックが外れるがコンテナは再起動しない。
+    DB 接続: engine.connect() + SELECT 1 (使い捨て接続で軽量)。
+    Redis 接続: get_redis().ping()。
+    """
+    # DB check
+    try:
+        async with engine.connect() as conn:
+            await conn.execute(text("SELECT 1"))
+    except Exception as exc:
+        raise HTTPException(status_code=503, detail=f"db_not_ready: {exc}") from exc
+
+    # Redis check
+    try:
+        from app.core.redis_client import get_redis
+
+        redis = await get_redis()
+        await redis.ping()
+    except Exception as exc:
+        raise HTTPException(status_code=503, detail=f"redis_not_ready: {exc}") from exc
+
+    return {"status": "ready", "service": "servicehub-api"}
 
 
 @app.get("/api/v1/status", tags=["System"])

--- a/backend/app/middleware/logging.py
+++ b/backend/app/middleware/logging.py
@@ -10,6 +10,7 @@ import structlog
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
 from starlette.responses import Response
+from structlog.contextvars import bind_contextvars, clear_contextvars
 
 logger = structlog.get_logger()
 
@@ -17,10 +18,24 @@ logger = structlog.get_logger()
 class RequestLoggingMiddleware(BaseHTTPMiddleware):
     """リクエスト/レスポンスの構造化ログ記録（ISO27001監査要件対応）"""
 
-    SKIP_PATHS = {"/health", "/docs", "/redoc", "/api/v1/openapi.json"}
+    # Health / metrics / docs paths skip verbose logging but still get X-Request-ID
+    SKIP_PATHS = {
+        "/health",
+        "/health/live",
+        "/health/ready",
+        "/metrics",
+        "/docs",
+        "/redoc",
+        "/api/v1/openapi.json",
+    }
 
     async def dispatch(self, request: Request, call_next) -> Response:
-        request_id = str(uuid.uuid4())
+        # Propagate X-Request-ID from upstream or generate a fresh one.
+        # Binding to structlog contextvars ensures all downstream log calls
+        # (handlers, services) automatically carry request_id without manual passing.
+        request_id = request.headers.get("X-Request-ID") or str(uuid.uuid4())
+        clear_contextvars()
+        bind_contextvars(request_id=request_id)
 
         if request.url.path in self.SKIP_PATHS:
             response = await call_next(request)
@@ -29,10 +44,8 @@ class RequestLoggingMiddleware(BaseHTTPMiddleware):
 
         start_time = time.perf_counter()
 
-        # リクエストログ
         logger.info(
             "request_start",
-            request_id=request_id,
             method=request.method,
             path=request.url.path,
             client_ip=request.client.host if request.client else "unknown",
@@ -41,10 +54,8 @@ class RequestLoggingMiddleware(BaseHTTPMiddleware):
         response = await call_next(request)
         elapsed_ms = round((time.perf_counter() - start_time) * 1000, 2)
 
-        # レスポンスログ
         logger.info(
             "request_end",
-            request_id=request_id,
             method=request.method,
             path=request.url.path,
             status_code=response.status_code,

--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -50,8 +50,7 @@ async def test_health_live():
 def _make_engine_mock(execute_side_effect=None):
     """AsyncEngine.connect() async context manager を模倣するモックを返す。
 
-    SQLAlchemy AsyncEngine.connect は read-only 属性のため patch("app.main.engine.connect")
-    では AttributeError になる。engine オブジェクト全体を差し替える方式を使う。
+    AsyncEngine.connect は read-only 属性のため engine オブジェクト全体を差し替える。
     """
     mock_conn = AsyncMock()
     if execute_side_effect:

--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -1,5 +1,7 @@
 """基本テスト - APIヘルスチェック確認"""
 
+from unittest.mock import AsyncMock, MagicMock, patch
+
 import pytest
 from httpx import ASGITransport, AsyncClient
 
@@ -8,7 +10,7 @@ from app.main import app
 
 @pytest.mark.asyncio
 async def test_health_check():
-    """ヘルスチェックエンドポイントの確認"""
+    """後方互換 /health エンドポイントの確認"""
     async with AsyncClient(
         transport=ASGITransport(app=app), base_url="http://test"
     ) as client:
@@ -30,3 +32,96 @@ async def test_api_status():
     data = response.json()
     assert data["success"] is True
     assert "ServiceHub" in data["data"]["api"]
+
+
+@pytest.mark.asyncio
+async def test_health_live():
+    """/health/live は DB/Redis なしで 200 を返す (liveness probe)"""
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        response = await client.get("/health/live")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "alive"
+    assert data["service"] == "servicehub-api"
+
+
+def _make_engine_mock(execute_side_effect=None):
+    """AsyncEngine.connect() async context manager を模倣するモックを返す。
+
+    SQLAlchemy AsyncEngine.connect は read-only 属性のため patch("app.main.engine.connect")
+    では AttributeError になる。engine オブジェクト全体を差し替える方式を使う。
+    """
+    mock_conn = AsyncMock()
+    if execute_side_effect:
+        mock_conn.execute = AsyncMock(side_effect=execute_side_effect)
+    else:
+        mock_conn.execute = AsyncMock()
+
+    # async with engine.connect() as conn: に対応する context manager
+    mock_ctx = AsyncMock()
+    mock_ctx.__aenter__ = AsyncMock(return_value=mock_conn)
+    mock_ctx.__aexit__ = AsyncMock(return_value=False)
+
+    mock_engine = MagicMock()
+    mock_engine.connect = MagicMock(return_value=mock_ctx)
+    return mock_engine
+
+
+@pytest.mark.asyncio
+async def test_health_ready_ok():
+    """/health/ready は DB+Redis 正常時に 200 を返す (readiness probe)"""
+    mock_engine = _make_engine_mock()
+
+    mock_redis = AsyncMock()
+    mock_redis.ping = AsyncMock(return_value=True)
+
+    with (
+        patch("app.main.engine", mock_engine),
+        patch("app.core.redis_client.get_redis", return_value=mock_redis),
+    ):
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            response = await client.get("/health/ready")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "ready"
+
+
+@pytest.mark.asyncio
+async def test_health_ready_db_failure():
+    """/health/ready は DB 接続失敗時に 503 を返す"""
+    mock_engine = _make_engine_mock(execute_side_effect=Exception("connection refused"))
+
+    with patch("app.main.engine", mock_engine):
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            response = await client.get("/health/ready")
+
+    assert response.status_code == 503
+    assert "db_not_ready" in response.json()["error"]["message"]
+
+
+@pytest.mark.asyncio
+async def test_health_ready_redis_failure():
+    """/health/ready は Redis ping 失敗時に 503 を返す"""
+    mock_engine = _make_engine_mock()
+
+    mock_redis = AsyncMock()
+    mock_redis.ping = AsyncMock(side_effect=Exception("redis timeout"))
+
+    with (
+        patch("app.main.engine", mock_engine),
+        patch("app.core.redis_client.get_redis", return_value=mock_redis),
+    ):
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            response = await client.get("/health/ready")
+
+    assert response.status_code == 503
+    assert "redis_not_ready" in response.json()["error"]["message"]

--- a/backend/tests/test_middleware.py
+++ b/backend/tests/test_middleware.py
@@ -1,0 +1,58 @@
+"""RequestLoggingMiddleware テスト — X-Request-ID 伝播と structlog contextvars"""
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.main import app
+
+
+@pytest.mark.asyncio
+async def test_request_id_generated_when_absent():
+    """X-Request-ID ヘッダが無い場合、レスポンスに新規 UUID が付与される"""
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        response = await client.get("/health/live")
+    assert "X-Request-ID" in response.headers
+    rid = response.headers["X-Request-ID"]
+    # UUID4 形式 (8-4-4-4-12)
+    assert len(rid) == 36
+    assert rid.count("-") == 4
+
+
+@pytest.mark.asyncio
+async def test_request_id_propagated_from_client():
+    """クライアントが X-Request-ID を送ると同じ値がレスポンスに返る (upstream 伝播)"""
+    upstream_id = "test-correlation-id-12345"
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        response = await client.get(
+            "/health/live", headers={"X-Request-ID": upstream_id}
+        )
+    assert response.headers.get("X-Request-ID") == upstream_id
+
+
+@pytest.mark.asyncio
+async def test_request_id_on_api_endpoint():
+    """API エンドポイントでも X-Request-ID がレスポンスヘッダに含まれる"""
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        response = await client.get("/api/v1/status")
+    assert "X-Request-ID" in response.headers
+
+
+@pytest.mark.asyncio
+async def test_skip_paths_no_verbose_logging():
+    """/health/* と /metrics は SKIP_PATHS に含まれ、200 を返す"""
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        live_resp = await client.get("/health/live")
+        health_resp = await client.get("/health")
+    assert live_resp.status_code == 200
+    assert health_resp.status_code == 200
+    # Both still get X-Request-ID even on skip paths
+    assert "X-Request-ID" in live_resp.headers
+    assert "X-Request-ID" in health_resp.headers


### PR DESCRIPTION
## 変更内容

Phase 6d Observability (#153 P1) の実装。既存コードを最大活用し、差分スコープに絞った実装。

### /health/live + /health/ready プローブ分離
| エンドポイント | 用途 | DB/Redis |
|---|---|---|
| `/health` | 後方互換 (維持) | なし |
| `/health/live` | Liveness probe — コンテナ再起動判断 | **なし** (DB 障害でも kill しない) |
| `/health/ready` | Readiness probe — トラフィック制御 | **あり** (503 → traffic off) |

### X-Request-ID correlation
- 上流から `X-Request-ID` ヘッダが来た場合はそのまま伝播 (トレース連携)
- 不在時は UUID4 を新規生成してレスポンスヘッダに付与
- SKIP_PATHS に `/health/live`・`/health/ready`・`/metrics` を追加

### structlog contextvars 統合
- `structlog.configure(processors=[merge_contextvars, ...])` をモジュール先頭で設定
- `bind_contextvars(request_id=...)` でリクエストスコープに request_id をバインド
- handler/service/repository 全ログ行に `request_id` フィールドが自動付与

## テスト結果

- `tests/test_health.py`: 6件 PASS (live・ready 正常/DB失敗/Redis失敗)
- `tests/test_middleware.py`: 4件 PASS (X-Request-ID 生成・伝播・スキップパス)
- ruff check + format: PASS
- mypy: 0 issues (2 files)
- ローカル全体: 324/329 PASS (残 5 件は Redis 依存 auth テスト = CI 専用の既知制約)

## 影響範囲

- `backend/app/main.py` — structlog.configure() + 2 エンドポイント追加
- `backend/app/middleware/logging.py` — X-Request-ID + contextvars bind + SKIP_PATHS 拡張
- `backend/tests/test_health.py` — 既存 2 件維持 + 新規 4 件追加
- `backend/tests/test_middleware.py` — 新規ファイル 4 件

## 残課題

- Prometheus custom metric (カウンター・ヒストグラム) 追加は Phase 6d 範囲外 → Issue #153 に記録

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * **ヘルスチェックエンドポイント拡張**: `/health/live` (プロセスの稼働状態確認) と `/health/ready` (DB・Redis接続状態確認) を追加
  * **リクエスト追跡の強化**: すべてのログエントリにリクエストIDが自動付与され、トレーサビリティが向上

* **テスト**
  * ヘルスチェックとミドルウェアの包括的なテストカバレッジを追加

<!-- end of auto-generated comment: release notes by coderabbit.ai -->