### PR TITLE
feat(phase7c): デプロイパイプライン整備 — GHCR push + staging smoke test + rollback 手順 (Closes #161)

### DIFF
--- a/.env.staging.example
+++ b/.env.staging.example
@@ -1,0 +1,44 @@
+# ServiceHub Construction Platform — Staging Environment Variables
+# Copy this file to .env.staging and fill in the actual values.
+# NEVER commit actual secrets to version control.
+
+# ─── Backend ──────────────────────────────────────────────────────────────────
+DATABASE_URL=postgresql+asyncpg://servicehub:<PASSWORD>@db:5432/servicehub_staging
+REDIS_URL=redis://redis:6379/0
+JWT_SECRET_KEY=<REPLACE_WITH_STRONG_RANDOM_SECRET_256BIT>
+JWT_ALGORITHM=HS256
+ACCESS_TOKEN_EXPIRE_MINUTES=30
+REFRESH_TOKEN_EXPIRE_DAYS=7
+ENVIRONMENT=staging
+LOG_LEVEL=INFO
+
+# ─── Frontend ─────────────────────────────────────────────────────────────────
+VITE_API_BASE_URL=https://staging.servicehub.example.com
+
+# ─── Database ─────────────────────────────────────────────────────────────────
+POSTGRES_USER=servicehub
+POSTGRES_PASSWORD=<REPLACE_WITH_STRONG_PASSWORD>
+POSTGRES_DB=servicehub_staging
+
+# ─── Container Registry ───────────────────────────────────────────────────────
+REGISTRY=ghcr.io
+IMAGE_OWNER=kensan196948g
+IMAGE_REPO=servicehub-construction-platform
+BACKEND_IMAGE=${REGISTRY}/${IMAGE_OWNER}/${IMAGE_REPO}/backend
+FRONTEND_IMAGE=${REGISTRY}/${IMAGE_OWNER}/${IMAGE_REPO}/frontend
+IMAGE_TAG=latest
+
+# ─── GitHub Secrets Setup Guide ───────────────────────────────────────────────
+# Required GitHub repository secrets (Settings → Secrets and variables → Actions):
+#
+# Secret Name                    Value
+# ──────────────────────────────────────────────────────────────────────────────
+# STAGING_DATABASE_URL           postgresql+asyncpg://...
+# STAGING_REDIS_URL              redis://...
+# STAGING_JWT_SECRET_KEY         <strong random 256-bit key>
+# STAGING_POSTGRES_PASSWORD      <strong password>
+# SMOKE_ADMIN_EMAIL              admin@servicehub.example
+# SMOKE_ADMIN_PASSWORD           <staging admin password>
+#
+# Note: GITHUB_TOKEN is automatically provided by GitHub Actions
+# and grants write access to ghcr.io for image push.

--- a/.github/workflows/ci-deploy-staging.yml
+++ b/.github/workflows/ci-deploy-staging.yml
@@ -1,0 +1,152 @@
+name: Deploy to Staging
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: "Docker image tag to deploy (default: sha-<commit>)"
+        required: false
+        default: ""
+
+concurrency:
+  group: deploy-staging
+  cancel-in-progress: false
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_OWNER: kensan196948g
+  IMAGE_REPO: servicehub-construction-platform
+
+jobs:
+  build-and-push:
+    name: Build & Push Docker Images
+    runs-on: ubuntu-latest
+    outputs:
+      image_tag: ${{ steps.meta.outputs.version }}
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Generate image tag
+        id: meta
+        env:
+          INPUT_TAG: ${{ github.event.inputs.image_tag }}
+          COMMIT_SHA: ${{ github.sha }}
+        run: |
+          TAG="$INPUT_TAG"
+          if [ -z "$TAG" ]; then
+            SHORT_SHA=$(echo "$COMMIT_SHA" | cut -c1-7)
+            TAG="sha-${SHORT_SHA}"
+          fi
+          echo "version=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "Image tag: ${TAG}"
+
+      - name: Build and push backend image
+        uses: docker/build-push-action@v6
+        with:
+          context: ./backend
+          file: ./backend/Dockerfile
+          target: production
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.IMAGE_REPO }}/backend:${{ steps.meta.outputs.version }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.IMAGE_REPO }}/backend:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Build and push frontend image
+        uses: docker/build-push-action@v6
+        with:
+          context: ./frontend
+          file: ./frontend/Dockerfile
+          target: production
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.IMAGE_REPO }}/frontend:${{ steps.meta.outputs.version }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.IMAGE_REPO }}/frontend:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  smoke-test:
+    name: Staging Smoke Test
+    runs-on: ubuntu-latest
+    needs: build-and-push
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Start staging services
+        run: docker compose -f docker-compose.staging.yml up -d
+        env:
+          IMAGE_TAG: ${{ needs.build-and-push.outputs.image_tag }}
+          POSTGRES_PASSWORD: staging-ci-password
+          JWT_SECRET_KEY: staging-ci-jwt-secret-key-for-testing-only
+
+      - name: Wait for API to be healthy
+        run: |
+          for i in $(seq 1 36); do
+            if curl -sf http://localhost:8000/health/live; then
+              echo "API is healthy"
+              break
+            fi
+            echo "Waiting for API... ($i/36)"
+            sleep 5
+          done
+
+      - name: Run smoke tests
+        run: |
+          chmod +x scripts/smoke-test.sh
+          ./scripts/smoke-test.sh
+        env:
+          BASE_URL: http://localhost:8000
+          SMOKE_ADMIN_EMAIL: admin@servicehub.example
+          SMOKE_ADMIN_PASSWORD: Admin1234!
+
+      - name: Show service logs on failure
+        if: failure()
+        run: docker compose -f docker-compose.staging.yml logs api --tail=100
+
+      - name: Tear down staging services
+        if: always()
+        run: docker compose -f docker-compose.staging.yml down -v --remove-orphans
+
+  notify-success:
+    name: Deployment Summary
+    runs-on: ubuntu-latest
+    needs: [build-and-push, smoke-test]
+    if: success()
+
+    steps:
+      - name: Write job summary
+        env:
+          IMAGE_TAG: ${{ needs.build-and-push.outputs.image_tag }}
+          IMAGE_OWNER: ${{ env.IMAGE_OWNER }}
+          IMAGE_REPO: ${{ env.IMAGE_REPO }}
+        run: |
+          {
+            echo "## Staging Deployment Successful"
+            echo ""
+            echo "| Item | Value |"
+            echo "|---|---|"
+            echo "| Image Tag | \`${IMAGE_TAG}\` |"
+            echo "| Smoke Tests | PASSED |"
+            echo "| Registry | ghcr.io/${IMAGE_OWNER}/${IMAGE_REPO} |"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -1,0 +1,79 @@
+version: "3.9"
+
+# Staging environment compose — used by ci-deploy-staging.yml.
+# Pulls pre-built images from GHCR and runs a smoke test against them.
+# For local staging simulation, set IMAGE_TAG and POSTGRES_PASSWORD env vars.
+
+services:
+  db:
+    image: postgres:15-alpine
+    environment:
+      POSTGRES_USER: servicehub
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-changeme}
+      POSTGRES_DB: servicehub_staging
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U servicehub -d servicehub_staging"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+    networks:
+      - staging-net
+
+  redis:
+    image: redis:7-alpine
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+    networks:
+      - staging-net
+
+  api:
+    image: ghcr.io/kensan196948g/servicehub-construction-platform/backend:${IMAGE_TAG:-latest}
+    environment:
+      DATABASE_URL: "postgresql+asyncpg://servicehub:${POSTGRES_PASSWORD:-changeme}@db:5432/servicehub_staging"
+      REDIS_URL: "redis://redis:6379/0"
+      JWT_SECRET_KEY: ${JWT_SECRET_KEY:-changeme-replace-in-production}
+      JWT_ALGORITHM: HS256
+      ENVIRONMENT: staging
+      LOG_LEVEL: INFO
+    command: >
+      sh -c "alembic upgrade head &&
+             python -m app.seeds.seed_test_data &&
+             uvicorn app.main:app --host 0.0.0.0 --port 8000 --workers 2"
+    ports:
+      - "8000:8000"
+    depends_on:
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:8000/health/live || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+    networks:
+      - staging-net
+
+  frontend:
+    image: ghcr.io/kensan196948g/servicehub-construction-platform/frontend:${IMAGE_TAG:-latest}
+    volumes:
+      - ./frontend/docker/nginx.test.conf:/etc/nginx/conf.d/default.conf:ro
+    ports:
+      - "3000:3000"
+    depends_on:
+      api:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:3000/ >/dev/null || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+    networks:
+      - staging-net
+
+networks:
+  staging-net:
+    driver: bridge

--- a/docs/deployment/rollback.md
+++ b/docs/deployment/rollback.md
@@ -1,0 +1,126 @@
+# ServiceHub Construction Platform — ロールバック手順書
+
+## 概要
+
+本ドキュメントは、staging/production 環境でデプロイに問題が発生した場合のロールバック手順を定義する。
+
+---
+
+## 1. 前提
+
+| 項目 | 内容 |
+|---|---|
+| コンテナレジストリ | `ghcr.io/kensan196948g/servicehub-construction-platform/` |
+| DB マイグレーション | Alembic (backend/alembic/) |
+| 環境変数 | GitHub Secrets / `.env.staging` |
+| ロールバックの最小単位 | 1 マイナーリリース (semver) または 1 PR |
+
+---
+
+## 2. Docker イメージの切り戻し
+
+### 2.1 前バージョンのタグを確認
+
+```bash
+# ghcr.io のイメージ一覧確認
+gh api /orgs/Kensan196948G/packages/container/servicehub-construction-platform%2Fbackend/versions \
+  --jq '.[].metadata.container.tags[]' | head -20
+```
+
+### 2.2 前バージョンのイメージでサービスを再起動
+
+```bash
+# 前バージョンのタグを指定 (例: sha-abc1234 または v1.2.3)
+export PREV_TAG="sha-abc1234"
+
+# docker-compose.staging.yml でイメージタグを上書き
+IMAGE_TAG=$PREV_TAG docker compose -f docker-compose.staging.yml up -d --no-build
+```
+
+### 2.3 ヘルスチェック確認
+
+```bash
+BASE_URL=https://staging.servicehub.example.com ./scripts/smoke-test.sh
+```
+
+---
+
+## 3. DB マイグレーションのロールバック
+
+### 3.1 現在のリビジョン確認
+
+```bash
+docker compose -f docker-compose.staging.yml exec api alembic current
+```
+
+### 3.2 1 リビジョン戻す
+
+```bash
+docker compose -f docker-compose.staging.yml exec api alembic downgrade -1
+```
+
+### 3.3 特定リビジョンまで戻す
+
+```bash
+# alembic history でリビジョン一覧を確認
+docker compose -f docker-compose.staging.yml exec api alembic history --verbose
+
+# 特定リビジョンまでダウングレード
+docker compose -f docker-compose.staging.yml exec api alembic downgrade <revision_id>
+```
+
+> **注意**: データの不可逆な変更（カラム削除・テーブル削除）を含む migration は、
+> ダウングレード前にデータバックアップを必ず取得すること。
+
+---
+
+## 4. 完全ロールバック手順 (緊急時)
+
+1. **現バージョンのサービスを停止**
+   ```bash
+   docker compose -f docker-compose.staging.yml down
+   ```
+
+2. **DB バックアップから復元** (DDL 変更を含む場合)
+   ```bash
+   # 事前に取得したバックアップから復元
+   docker compose -f docker-compose.staging.yml run --rm db \
+     psql -U servicehub servicehub_staging < /backup/pre-deploy-backup.sql
+   ```
+
+3. **前バージョンのイメージを起動**
+   ```bash
+   IMAGE_TAG=$PREV_TAG docker compose -f docker-compose.staging.yml up -d
+   ```
+
+4. **Smoke test で確認**
+   ```bash
+   BASE_URL=https://staging.servicehub.example.com ./scripts/smoke-test.sh
+   ```
+
+5. **Issue を起票して原因を追跡**
+   - ラベル: `P1`, `bug`, `deployment`
+   - 本文: 発生時刻・症状・実施したロールバック手順・次のアクション
+
+---
+
+## 5. デプロイ前チェックリスト
+
+デプロイ前に以下を確認すること。
+
+- [ ] `alembic upgrade head` が冪等 (再実行しても安全) であることを確認
+- [ ] breaking な DB 変更がある場合は、old/new コードの互換性を確認
+- [ ] `docker compose config` でyaml構文エラーがないことを確認
+- [ ] `.env.staging` の secrets が最新であることを確認
+- [ ] 直前の main ブランチの CI が全 green であることを確認
+
+---
+
+## 6. 連絡先・エスカレーション
+
+| 役割 | 対応内容 |
+|---|---|
+| DevOps | CI/CD パイプライン障害 |
+| Backend Developer | DB migration / API エラー |
+| Frontend Developer | 静的ファイル配信・SPA ルーティング問題 |
+| CTO | 全体判断・本番ロールバック最終決定 |

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# smoke-test.sh — Post-deploy smoke test for ServiceHub Construction Platform
+# Usage: BASE_URL=https://staging.example.com ./scripts/smoke-test.sh
+# Exit 0 = all checks passed, non-zero = at least one check failed.
+
+set -euo pipefail
+
+BASE_URL="${BASE_URL:-http://localhost:8000}"
+ADMIN_EMAIL="${SMOKE_ADMIN_EMAIL:-admin@servicehub.example}"
+ADMIN_PASSWORD="${SMOKE_ADMIN_PASSWORD:-Admin1234!}"
+
+PASS=0
+FAIL=0
+
+check() {
+  local name="$1"
+  local status="$2"
+  local expected="$3"
+  if [ "$status" = "$expected" ]; then
+    echo "[PASS] $name (HTTP $status)"
+    PASS=$((PASS + 1))
+  else
+    echo "[FAIL] $name — expected HTTP $expected, got $status"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+echo "=== ServiceHub Smoke Test ==="
+echo "BASE_URL: $BASE_URL"
+echo ""
+
+# 1. Liveness probe
+STATUS=$(curl -s -o /dev/null -w "%{http_code}" "$BASE_URL/health/live")
+check "/health/live" "$STATUS" "200"
+
+# 2. Readiness probe
+STATUS=$(curl -s -o /dev/null -w "%{http_code}" "$BASE_URL/health/ready")
+check "/health/ready" "$STATUS" "200"
+
+# 3. Unauthenticated API returns 401
+STATUS=$(curl -s -o /dev/null -w "%{http_code}" "$BASE_URL/api/v1/projects")
+check "GET /api/v1/projects (no auth) → 401" "$STATUS" "401"
+
+# 4. Login returns 200 with token
+LOGIN_RESPONSE=$(curl -s -w "\n%{http_code}" -X POST "$BASE_URL/api/v1/auth/login" \
+  -H "Content-Type: application/json" \
+  -d "{\"email\":\"$ADMIN_EMAIL\",\"password\":\"$ADMIN_PASSWORD\"}")
+LOGIN_STATUS=$(echo "$LOGIN_RESPONSE" | tail -1)
+LOGIN_BODY=$(echo "$LOGIN_RESPONSE" | head -n -1)
+check "POST /api/v1/auth/login" "$LOGIN_STATUS" "200"
+
+# 5. Authenticated projects list
+if [ "$LOGIN_STATUS" = "200" ]; then
+  TOKEN=$(echo "$LOGIN_BODY" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('access_token',''))" 2>/dev/null || true)
+  if [ -n "$TOKEN" ]; then
+    STATUS=$(curl -s -o /dev/null -w "%{http_code}" "$BASE_URL/api/v1/projects" \
+      -H "Authorization: Bearer $TOKEN")
+    check "GET /api/v1/projects (with auth) → 200" "$STATUS" "200"
+  else
+    echo "[SKIP] Bearer token not found in login response"
+    FAIL=$((FAIL + 1))
+  fi
+else
+  echo "[SKIP] Authenticated projects test — login failed"
+  FAIL=$((FAIL + 1))
+fi
+
+# 6. Dashboard KPI endpoint
+if [ -n "${TOKEN:-}" ]; then
+  STATUS=$(curl -s -o /dev/null -w "%{http_code}" "$BASE_URL/api/v1/dashboard/kpi" \
+    -H "Authorization: Bearer $TOKEN")
+  check "GET /api/v1/dashboard/kpi (with auth) → 200" "$STATUS" "200"
+fi
+
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi


### PR DESCRIPTION
## 概要

Phase 7c (#161) — 本番リリースに向けたデプロイパイプラインと smoke test の整備

## 変更内容

### 追加
- **`.github/workflows/ci-deploy-staging.yml`**: staging デプロイワークフロー
  - トリガー: main push + workflow_dispatch (手動 image_tag 指定可)
  - `build-and-push` job: backend/frontend Docker イメージを ghcr.io にビルド & push (BuildKit layer cache 有効)
  - `smoke-test` job: docker-compose.staging.yml でサービス起動 → `smoke-test.sh` 実行
  - `notify-success` job: GitHub Step Summary にデプロイ結果を出力
- **`docker-compose.staging.yml`**: GHCR イメージを使った staging 疑似環境
  - db (postgres:15) + redis:7 + api + frontend
  - `IMAGE_TAG` 環境変数でデプロイバージョンを制御
  - `nginx.test.conf` でAPIプロキシ設定
- **`scripts/smoke-test.sh`**: デプロイ後 smoke test スクリプト
  - 6 チェック: /health/live, /health/ready, 認証なし 401, ログイン、認証付き projects、KPI
  - `BASE_URL`, `SMOKE_ADMIN_EMAIL`, `SMOKE_ADMIN_PASSWORD` で設定可能
- **`docs/deployment/rollback.md`**: ロールバック手順書
  - Docker イメージ切り戻し手順
  - Alembic downgrade 手順
  - 緊急時完全ロールバック手順
  - デプロイ前チェックリスト
- **`.env.staging.example`**: staging 環境変数テンプレート + GitHub Secrets 設定ガイド

## 影響範囲

- CI: main push 時に staging deploy workflow が起動
- 本番コード: 変更なし
- Docs: `docs/deployment/rollback.md` 追加

## 残課題

- Phase 7c はデプロイパイプライン基盤の整備まで。実際の staging サーバーへのデプロイは Phase 8 (Month 6) で対応予定

🤖 Generated by ClaudeOS v8 CTO Agent (Phase 7c)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ステージング環境への自動デプロイメント機能を追加しました。コミット時にDockerイメージが自動的にビルド・プッシュされます。
  * デプロイ後の自動スモークテストを実装しました。

* **ドキュメント**
  * ステージング環境のロールバック手順書を追加しました。

* **その他**
  * ステージング環境の設定ファイルとDocker Compose設定を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->