### PR TITLE
feat(phase9a): Prometheus + Grafana 監視スタック構築 (Closes #165)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # 使用方法: make <command>
 # ================================================
 
-.PHONY: help up down build logs shell-api shell-db migrate seed test lint clean
+.PHONY: help up down build logs shell-api shell-db migrate seed test lint clean monitoring-up monitoring-down monitoring-logs
 
 ## ヘルプ
 help:
@@ -95,6 +95,20 @@ clean: ## 一時ファイル削除
 	find . -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true
 	find . -name "*.pyc" -delete 2>/dev/null || true
 	find . -name ".pytest_cache" -exec rm -rf {} + 2>/dev/null || true
+
+## 監視スタック (Phase 9a)
+monitoring-up: ## 監視スタック起動 (Prometheus/Grafana/Alertmanager)
+	docker compose -f docker-compose.yml -f docker-compose.monitoring.yml up -d prometheus alertmanager grafana node-exporter postgres-exporter redis-exporter
+	@echo "✅ 監視スタック起動完了"
+	@echo "  Grafana:      http://localhost:3001 (admin/admin)"
+	@echo "  Prometheus:   http://localhost:9090"
+	@echo "  Alertmanager: http://localhost:9093"
+
+monitoring-down: ## 監視スタック停止
+	docker compose -f docker-compose.yml -f docker-compose.monitoring.yml stop prometheus alertmanager grafana node-exporter postgres-exporter redis-exporter
+
+monitoring-logs: ## 監視スタックログ
+	docker compose -f docker-compose.yml -f docker-compose.monitoring.yml logs -f prometheus grafana alertmanager
 
 ## セットアップ
 setup: ## 初回セットアップ

--- a/README.md
+++ b/README.md
@@ -178,8 +178,8 @@ graph TB
 | ✅ CI チェック数 | **19 チェック**（ruff / mypy / pytest / integration / bandit / **Trivy コンテナスキャン** / vitest / build / E2E / dependency / type-check x2 / test-coverage x2 / lint-build x2 + Lighthouse CI + **Fullstack E2E** + **weekly 負荷テスト**） |
 | 📊 Prometheus メトリクス | **有効**（`/metrics` エンドポイント / 全ルート RED メトリクス自動計測） |
 | ⚡ Web Vitals | **有効**（LCP / INP / CLS / TTFB / FCP / web-vitals v5） |
-| 🔒 STABLE 判定 | **達成**（Phase 7 全完了 / **Phase 8 進行中** — v0.8.0タグ / 本番Compose整備 / Trivy追加 / ベンチマーク修正） |
-| 🛡️ Trivy セキュリティスキャン | **追加済み** (Phase 8c — CRITICAL/HIGH 脆弱性ゼロ目標 / backend + frontend イメージをスキャン) |
+| 🔒 STABLE 判定 | **達成**（Phase 8 STABLE完了 **v0.8.1** タグ付与 / 全CVE修正 / Phase 9 監視スタック構築中） |
+| 🛡️ Trivy セキュリティスキャン | **CRITICAL/HIGH=0 達成済** (Phase 8c v0.8.1 — python-jose 3.5.0 / python-multipart 0.0.26 / starlette 0.49.1 / fastapi 0.124.4 / nginx:1.27-alpine) |
 
 ### 🏗️ Backend アーキテクチャ
 
@@ -375,7 +375,8 @@ gantt
 | 🟣 Phase 5 リリース準備 | 4月 PR#129-#149 | Docker 本番構成・Lighthouse・Coverage 85→95%・OpenAPI codegen・WebUI デザインシステム (5a/5b/5c/5d/5e-1〜5e-5) | ✅ 完了 |
 | 🟣 Phase 6 品質強化 + リリース準備 | 2026-05〜08 | 6a Backend coverage (#146 ✅) / 6c E2E Photos/Safety/Cost (#147 #151 ✅) / 6b Integration&Contract tests (#152) / 6d Observability (#153) / 6e Security hardening (#154) | ✅ 完了 |
 | 🟢 Phase 7 リリース | 2026-09〜10 | 統合テスト・本番移行・**社内公開** 🎉 E2E 221件 / CI 18チェック / Docker Compose 本番化 | ✅ 完了 |
-| 🚀 Phase 8 本番リリース準備 | 2026-04 | v0.8.0タグ / 本番Compose整備 / Trivyセキュリティスキャン / ベンチマーク修正 / CI 19チェック | 🔄 進行中 |
+| 🚀 Phase 8 本番リリース準備 | 2026-04 | v0.8.0タグ / 本番Compose整備 / Trivyセキュリティスキャン / ベンチマーク修正 / CI 19チェック — **v0.8.1 STABLE ✅ CVE CRITICAL/HIGH=0** | ✅ 完了 |
+| 🔵 Phase 9 本番運用準備 | 2026-04〜05 | 9a Prometheus/Grafana監視スタック / 9b k6拡充+SLO / 9c Kubernetes Helm chart | 🔄 進行中 |
 
 ---
 
@@ -642,6 +643,55 @@ graph TD
 | 📖 API ドキュメント   | http://localhost/api/v1/docs     |
 | 📡 ヘルスチェック     | http://localhost/health          |
 | 🪣 MinIO Console     | http://localhost:9001            |
+| 📊 Grafana           | http://localhost:3001 (monitoring stack) |
+| 🔥 Prometheus        | http://localhost:9090 (monitoring stack) |
+| 🔔 Alertmanager      | http://localhost:9093 (monitoring stack) |
+
+---
+
+## 📊 監視スタック（Phase 9a）
+
+Prometheus + Grafana + Alertmanager による本番監視基盤を提供します。
+
+```bash
+# 監視スタック起動（メインスタックが起動済みであること）
+make monitoring-up
+
+# または直接 docker compose で起動
+docker compose -f docker-compose.yml -f docker-compose.monitoring.yml up -d
+```
+
+### 監視コンポーネント
+
+| コンポーネント          | バージョン      | 役割                              |
+| :---------------------- | :------------- | :-------------------------------- |
+| Prometheus              | v2.54.1        | メトリクス収集・保管（30日保存）    |
+| Grafana                 | 11.3.0         | ダッシュボード可視化               |
+| Alertmanager            | v0.27.0        | アラート管理・通知                 |
+| Node Exporter           | v1.8.2         | サーバーリソース監視               |
+| postgres-exporter       | v0.15.0        | PostgreSQL メトリクス              |
+| redis-exporter          | v1.62.0        | Redis メトリクス                   |
+
+### アラートルール（SLO）
+
+| アラート                  | 条件                          | 重大度     |
+| :------------------------ | :---------------------------- | :--------- |
+| APIHighErrorRate          | HTTP 5xx 率 > 2%              | critical   |
+| APIHighLatencyP95         | P95 レイテンシ > 1s           | warning    |
+| APIVeryHighLatencyP95     | P95 レイテンシ > 3s           | critical   |
+| APIDown                   | API 疎通不可 1分以上           | critical   |
+| PostgreSQLDown            | DB 疎通不可 1分以上            | critical   |
+| HighCPUUsage              | CPU > 90% 5分間               | critical   |
+| HighMemoryUsage           | メモリ > 90% 5分間             | critical   |
+| DiskSpaceLow              | ディスク > 85% 10分間          | warning    |
+
+### FastAPI メトリクス
+
+`/metrics` エンドポイント（Prometheus 形式）で以下を自動計測：
+
+- `http_requests_total` — リクエスト数（エンドポイント / ステータス別）
+- `http_request_duration_seconds` — レイテンシヒストグラム（P50/P95/P99）
+- `http_requests_in_progress` — 処理中リクエスト数
 
 ---
 

--- a/docker-compose.monitoring.yml
+++ b/docker-compose.monitoring.yml
@@ -1,0 +1,129 @@
+# ServiceHub Construction Platform - Monitoring Stack
+# Usage (overlay): docker compose -f docker-compose.yml -f docker-compose.monitoring.yml up
+# Usage (standalone): docker compose -f docker-compose.monitoring.yml up  (main stack must be running)
+#
+# Provides: Prometheus / Grafana / Alertmanager / Exporters
+# Grafana:      http://localhost:3001  (admin / ${GRAFANA_ADMIN_PASSWORD:-admin})
+# Prometheus:   http://localhost:9090
+# Alertmanager: http://localhost:9093
+
+services:
+  prometheus:
+    image: prom/prometheus:v2.54.1
+    container_name: servicehub-prometheus
+    restart: unless-stopped
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - ./prometheus/alerts.yml:/etc/prometheus/alerts.yml:ro
+      - prometheus-data:/prometheus
+    command:
+      - "--config.file=/etc/prometheus/prometheus.yml"
+      - "--storage.tsdb.path=/prometheus"
+      - "--storage.tsdb.retention.time=30d"
+      - "--web.console.libraries=/etc/prometheus/console_libraries"
+      - "--web.console.templates=/etc/prometheus/consoles"
+      - "--web.enable-lifecycle"
+    networks:
+      - servicehub-net
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:9090/-/healthy"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+
+  alertmanager:
+    image: prom/alertmanager:v0.27.0
+    container_name: servicehub-alertmanager
+    restart: unless-stopped
+    ports:
+      - "9093:9093"
+    volumes:
+      - ./prometheus/alertmanager.yml:/etc/alertmanager/alertmanager.yml:ro
+      - alertmanager-data:/alertmanager
+    command:
+      - "--config.file=/etc/alertmanager/alertmanager.yml"
+      - "--storage.path=/alertmanager"
+      - "--web.listen-address=0.0.0.0:9093"
+    networks:
+      - servicehub-net
+
+  grafana:
+    image: grafana/grafana:11.3.0
+    container_name: servicehub-grafana
+    restart: unless-stopped
+    ports:
+      - "3001:3000"
+    environment:
+      GF_SECURITY_ADMIN_USER: admin
+      GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASSWORD:-admin}
+      GF_USERS_ALLOW_SIGN_UP: "false"
+      GF_SERVER_ROOT_URL: "http://localhost:3001"
+      GF_INSTALL_PLUGINS: ""
+      GF_LOG_LEVEL: warn
+    volumes:
+      - ./grafana/provisioning:/etc/grafana/provisioning:ro
+      - ./grafana/dashboards:/var/lib/grafana/dashboards:ro
+      - grafana-data:/var/lib/grafana
+    networks:
+      - servicehub-net
+    depends_on:
+      - prometheus
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:3000/api/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+
+  node-exporter:
+    image: prom/node-exporter:v1.8.2
+    container_name: servicehub-node-exporter
+    restart: unless-stopped
+    ports:
+      - "9100:9100"
+    volumes:
+      - /proc:/host/proc:ro
+      - /sys:/host/sys:ro
+      - /:/rootfs:ro
+    command:
+      - "--path.procfs=/host/proc"
+      - "--path.rootfs=/rootfs"
+      - "--path.sysfs=/host/sys"
+      - "--collector.filesystem.mount-points-exclude=^/(sys|proc|dev|host|etc)($$|/)"
+    networks:
+      - servicehub-net
+
+  postgres-exporter:
+    image: prometheuscommunity/postgres-exporter:v0.15.0
+    container_name: servicehub-postgres-exporter
+    restart: unless-stopped
+    ports:
+      - "9187:9187"
+    environment:
+      DATA_SOURCE_NAME: "postgresql://${POSTGRES_USER:-servicehub}:${POSTGRES_PASSWORD:-servicehub_pass}@db:5432/${POSTGRES_DB:-servicehub_db}?sslmode=disable"
+    networks:
+      - servicehub-net
+
+  redis-exporter:
+    image: oliver006/redis_exporter:v1.62.0
+    container_name: servicehub-redis-exporter
+    restart: unless-stopped
+    ports:
+      - "9121:9121"
+    environment:
+      REDIS_ADDR: "redis://redis:6379"
+    networks:
+      - servicehub-net
+
+volumes:
+  prometheus-data:
+    driver: local
+  alertmanager-data:
+    driver: local
+  grafana-data:
+    driver: local
+
+networks:
+  servicehub-net:
+    external: true

--- a/grafana/dashboards/servicehub-api.json
+++ b/grafana/dashboards/servicehub-api.json
@@ -1,0 +1,480 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "10.0.0"
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "stat",
+      "name": "Stat",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "gauge",
+      "name": "Gauge",
+      "version": ""
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": { "type": "grafana", "uid": "-- Grafana --" },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "ServiceHub Construction Platform — API Metrics Dashboard",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "red", "value": 80 }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 0 },
+      "id": 1,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "title": "Request Rate (RPS)",
+      "type": "stat",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "sum(rate(http_requests_total{job=\"servicehub-api\"}[5m]))",
+          "legendFormat": "Total RPS",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 0.005 },
+              { "color": "red", "value": 0.02 }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 6, "x": 6, "y": 0 },
+      "id": 2,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "title": "Error Rate (5xx)",
+      "type": "stat",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "sum(rate(http_requests_total{job=\"servicehub-api\",status=~\"5..\"}[5m])) / sum(rate(http_requests_total{job=\"servicehub-api\"}[5m]))",
+          "legendFormat": "5xx Error Rate",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 0.3 },
+              { "color": "red", "value": 1.0 }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 6, "x": 12, "y": 0 },
+      "id": 3,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "title": "P95 Latency",
+      "type": "stat",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "histogram_quantile(0.95, sum(rate(http_request_duration_seconds_bucket{job=\"servicehub-api\"}[5m])) by (le))",
+          "legendFormat": "P95",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 50 },
+              { "color": "red", "value": 80 }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 6, "x": 18, "y": 0 },
+      "id": 4,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "title": "Active Connections (In-flight)",
+      "type": "stat",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "http_requests_in_progress{job=\"servicehub-api\"}",
+          "legendFormat": "In-flight",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "red", "value": 80 }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 4 },
+      "id": 5,
+      "options": {
+        "legend": { "calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "none" }
+      },
+      "title": "Request Rate by Endpoint",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "sum by (handler) (rate(http_requests_total{job=\"servicehub-api\"}[5m]))",
+          "legendFormat": "{{ handler }}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": {
+              "mode": "line",
+              "steps": [
+                { "color": "transparent", "value": null },
+                { "color": "yellow", "value": 0.3 },
+                { "color": "red", "value": 1.0 }
+              ]
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 0.3 },
+              { "color": "red", "value": 1.0 }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 4 },
+      "id": 6,
+      "options": {
+        "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "none" }
+      },
+      "title": "Response Latency (P50 / P95 / P99)",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "histogram_quantile(0.50, sum(rate(http_request_duration_seconds_bucket{job=\"servicehub-api\"}[5m])) by (le))",
+          "legendFormat": "P50",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "histogram_quantile(0.95, sum(rate(http_request_duration_seconds_bucket{job=\"servicehub-api\"}[5m])) by (le))",
+          "legendFormat": "P95",
+          "refId": "B"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "histogram_quantile(0.99, sum(rate(http_request_duration_seconds_bucket{job=\"servicehub-api\"}[5m])) by (le))",
+          "legendFormat": "P99",
+          "refId": "C"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "normal" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "green", "value": null }]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 12 },
+      "id": 7,
+      "options": {
+        "legend": { "calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "none" }
+      },
+      "title": "HTTP Status Code Distribution",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "sum by (status) (rate(http_requests_total{job=\"servicehub-api\"}[5m]))",
+          "legendFormat": "HTTP {{ status }}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "green", "value": null }]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 12 },
+      "id": 8,
+      "options": {
+        "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "none" }
+      },
+      "title": "Process Memory Usage",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "process_resident_memory_bytes{job=\"servicehub-api\"}",
+          "legendFormat": "RSS Memory",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "process_virtual_memory_bytes{job=\"servicehub-api\"}",
+          "legendFormat": "Virtual Memory",
+          "refId": "B"
+        }
+      ]
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 38,
+  "tags": ["servicehub", "api", "fastapi"],
+  "templating": {
+    "list": []
+  },
+  "time": { "from": "now-1h", "to": "now" },
+  "timepicker": {},
+  "timezone": "Asia/Tokyo",
+  "title": "ServiceHub API Dashboard",
+  "uid": "servicehub-api",
+  "version": 1
+}

--- a/grafana/provisioning/dashboards/dashboards.yml
+++ b/grafana/provisioning/dashboards/dashboards.yml
@@ -1,0 +1,12 @@
+apiVersion: 1
+
+providers:
+  - name: "ServiceHub Dashboards"
+    orgId: 1
+    folder: "ServiceHub"
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 30
+    allowUiUpdates: true
+    options:
+      path: /var/lib/grafana/dashboards

--- a/grafana/provisioning/datasources/prometheus.yml
+++ b/grafana/provisioning/datasources/prometheus.yml
@@ -1,0 +1,14 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    uid: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    jsonData:
+      timeInterval: "15s"
+      queryTimeout: "60s"
+      httpMethod: POST
+    editable: false

--- a/prometheus/alertmanager.yml
+++ b/prometheus/alertmanager.yml
@@ -1,0 +1,44 @@
+global:
+  resolve_timeout: 5m
+  smtp_smarthost: "localhost:587"
+  smtp_from: "alertmanager@servicehub.example.com"
+
+route:
+  group_by: ["alertname", "severity"]
+  group_wait: 30s
+  group_interval: 5m
+  repeat_interval: 12h
+  receiver: "default"
+  routes:
+    - match:
+        severity: critical
+      receiver: "critical"
+      repeat_interval: 1h
+    - match:
+        severity: warning
+      receiver: "default"
+
+receivers:
+  - name: "default"
+    email_configs:
+      - to: "ops-team@servicehub.example.com"
+        send_resolved: true
+
+  - name: "critical"
+    email_configs:
+      - to: "on-call@servicehub.example.com"
+        send_resolved: true
+    # Uncomment to enable Slack notifications:
+    # slack_configs:
+    #   - api_url: "${SLACK_WEBHOOK_URL}"
+    #     channel: "#alerts-critical"
+    #     send_resolved: true
+    #     title: "{{ .GroupLabels.alertname }}"
+    #     text: "{{ range .Alerts }}{{ .Annotations.description }}{{ end }}"
+
+inhibit_rules:
+  - source_match:
+      severity: critical
+    target_match:
+      severity: warning
+    equal: ["alertname", "instance"]

--- a/prometheus/alerts.yml
+++ b/prometheus/alerts.yml
@@ -1,0 +1,100 @@
+groups:
+  - name: servicehub.api
+    rules:
+      - alert: APIHighErrorRate
+        expr: |
+          sum(rate(http_requests_total{status=~"5.."}[5m])) /
+          sum(rate(http_requests_total[5m])) > 0.02
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: "API error rate exceeds 2%"
+          description: "HTTP 5xx error rate is {{ $value | humanizePercentage }} over the last 5 minutes."
+
+      - alert: APIHighLatencyP95
+        expr: |
+          histogram_quantile(0.95,
+            sum(rate(http_request_duration_seconds_bucket[5m])) by (le)
+          ) > 1.0
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "API P95 latency exceeds 1s"
+          description: "P95 response time is {{ $value | humanizeDuration }}."
+
+      - alert: APIVeryHighLatencyP95
+        expr: |
+          histogram_quantile(0.95,
+            sum(rate(http_request_duration_seconds_bucket[5m])) by (le)
+          ) > 3.0
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: "API P95 latency exceeds 3s"
+          description: "P95 response time is {{ $value | humanizeDuration }}."
+
+      - alert: APIDown
+        expr: up{job="servicehub-api"} == 0
+        for: 1m
+        labels:
+          severity: critical
+        annotations:
+          summary: "ServiceHub API is down"
+          description: "The API instance has been unreachable for more than 1 minute."
+
+  - name: servicehub.db
+    rules:
+      - alert: PostgreSQLDown
+        expr: up{job="postgres"} == 0
+        for: 1m
+        labels:
+          severity: critical
+        annotations:
+          summary: "PostgreSQL is down"
+          description: "PostgreSQL exporter has been unreachable for more than 1 minute."
+
+      - alert: PostgreSQLHighConnections
+        expr: |
+          pg_stat_activity_count / pg_settings_max_connections > 0.8
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "PostgreSQL connection usage > 80%"
+          description: "{{ $value | humanizePercentage }} of max connections are in use."
+
+  - name: servicehub.infra
+    rules:
+      - alert: HighCPUUsage
+        expr: |
+          100 - (avg by (instance) (rate(node_cpu_seconds_total{mode="idle"}[5m])) * 100) > 90
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "High CPU usage on {{ $labels.instance }}"
+          description: "CPU usage is {{ $value | humanize }}%."
+
+      - alert: HighMemoryUsage
+        expr: |
+          (1 - node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes) * 100 > 90
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "High memory usage on {{ $labels.instance }}"
+          description: "Memory usage is {{ $value | humanize }}%."
+
+      - alert: DiskSpaceLow
+        expr: |
+          (1 - node_filesystem_avail_bytes{mountpoint="/"} /
+               node_filesystem_size_bytes{mountpoint="/"}) * 100 > 85
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Disk space below 15% on {{ $labels.instance }}"
+          description: "Disk usage is {{ $value | humanize }}%."

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -1,0 +1,40 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+  external_labels:
+    monitor: "servicehub"
+
+rule_files:
+  - "alerts.yml"
+
+alerting:
+  alertmanagers:
+    - static_configs:
+        - targets:
+            - alertmanager:9093
+
+scrape_configs:
+  - job_name: "prometheus"
+    static_configs:
+      - targets: ["localhost:9090"]
+
+  - job_name: "servicehub-api"
+    metrics_path: /metrics
+    static_configs:
+      - targets: ["api:8000"]
+    relabel_configs:
+      - source_labels: [__address__]
+        target_label: instance
+        replacement: "servicehub-api"
+
+  - job_name: "postgres"
+    static_configs:
+      - targets: ["postgres-exporter:9187"]
+
+  - job_name: "redis"
+    static_configs:
+      - targets: ["redis-exporter:9121"]
+
+  - job_name: "node"
+    static_configs:
+      - targets: ["node-exporter:9100"]

--- a/state.json
+++ b/state.json
@@ -9,11 +9,11 @@
     "release_policy": "半年後の本番リリース絶対厳守。残日数による自動縮退: <=30日 Improvement縮退 / <=14日 新機能開発禁止 / <=7日 リリース準備のみ",
     "phase_flexibility": "Monitor/Development/Verify/Improvement の配分は進捗に応じて CTO 判断で自由変更可 (リリース期限制約の下で)"
   },
-  "phase": "Phase 8 — リリース準備・本番移行 (2026-10-03 絶対厳守)",
-  "loop": "Day25-Phase8-InProgress",
-  "loop_count": 148,
+  "phase": "Phase 9 — 本番運用準備 (Kubernetes / 監視強化 / 負荷試験本格化)",
+  "loop": "Day25-Phase9a-MonitoringStack",
+  "loop_count": 149,
   "status": "active",
-  "last_updated": "2026-04-25T15:30:00+09:00",
+  "last_updated": "2026-04-25T17:00:00+09:00",
   "execution": {
     "start_time": "2026-04-25T07:00:00+09:00",
     "max_duration_minutes": 300,
@@ -27,7 +27,7 @@
     "previous_session_id": "20260423-212928-ServiceHub-Construction-Platform"
   },
   "goal": {
-    "title": "Phase 8 — 本番リリース準備 (v0.8.0 / セキュリティ・パフォーマンス・ドキュメント整備)"
+    "title": "Phase 9 — 本番運用準備 (監視スタック / 負荷試験 / Kubernetes)"
   },
   "kpi": {
     "success_rate_target": 0.9,
@@ -241,10 +241,10 @@
     }
   },
   "resume_point": {
-    "action": "Phase 8 全タスク (8a〜8e) 完了 → CI Trivy結果待ち (0cc2dca)",
-    "branch": "main",
-    "next_phase": "Trivy CRITICAL/HIGH=0確認後 → Phase 8 STABLE判定 → 本番リリースゲート確認",
-    "phase8_progress_note": "2026-04-25 8a/8b/8c/8d/8e 全完了。trivy-action@v0.36.0 で CI 修正済み。CI実行中"
+    "action": "Phase 9a 監視スタック実装完了 → feat/phase9a-monitoring PR 作成待ち",
+    "branch": "feat/phase9a-monitoring",
+    "next_phase": "Phase 9a PR merge → Phase 9b 負荷試験拡充 (Issue #166) → Phase 9c Kubernetes Helm (Issue #167)",
+    "phase9a_progress_note": "2026-04-25 prometheus/ grafana/ docker-compose.monitoring.yml Makefile README.md 全作成完了"
   },
   "phase6_plan": {
     "kickoff_at": "2026-04-24",
@@ -331,6 +331,36 @@
         "note": "README ロードマップ更新 / CI チェック数 19 / Phase 6+7 完了 / Phase 8 進行中"
       }
     },
-    "next": "Phase 8 STABLE完了 (v0.8.1タグ付与) → Phase 9 本番運用準備 (Kubernetes / 監視 / 負荷試験本格化) または 次セッションで振り返り"
+    "next": "Phase 9 本番運用準備 — 9a監視スタック実装済み / 9b負荷試験拡充 / 9c Kubernetes Helm chart"
+  },
+  "phase9_plan": {
+    "kickoff_at": "2026-04-25",
+    "phase_9a_monitoring": {
+      "status": "in_progress",
+      "issue": "#165",
+      "branch": "feat/phase9a-monitoring",
+      "scope": "Prometheus + Grafana + Alertmanager 監視スタック / docker-compose.monitoring.yml overlay",
+      "files_created": [
+        "prometheus/prometheus.yml",
+        "prometheus/alerts.yml",
+        "prometheus/alertmanager.yml",
+        "grafana/provisioning/datasources/prometheus.yml",
+        "grafana/provisioning/dashboards/dashboards.yml",
+        "grafana/dashboards/servicehub-api.json",
+        "docker-compose.monitoring.yml",
+        "Makefile (monitoring-up/down/logs 追加)"
+      ],
+      "note": "prometheus-fastapi-instrumentator は Phase 3a で既実装済み。api:8000/metrics をスクレイプ設定。SLO アラート 9種定義。Grafana 8パネルダッシュボード自動プロビジョニング"
+    },
+    "phase_9b_load_test": {
+      "status": "planned",
+      "issue": "#166",
+      "scope": "k6 負荷試験シナリオ拡充 + SLO 基準明文化 (P95 < 1s@100RPS)"
+    },
+    "phase_9c_kubernetes": {
+      "status": "planned",
+      "issue": "#167",
+      "scope": "Kubernetes Helm chart 骨格 + namespace / RBAC / HPA 設定"
+    }
   }
 }


### PR DESCRIPTION
## 概要

Phase 9a — 本番運用監視スタックを `docker-compose.monitoring.yml` overlay パターンで構築。
`prometheus-fastapi-instrumentator` が Phase 3a で既実装済みのため、Prometheus 側スクレイプ設定追加のみでメトリクス収集が即時有効になります。

## 変更内容

### 新規ファイル

| ファイル | 説明 |
|---|---|
| `docker-compose.monitoring.yml` | 監視スタック全体 (Prometheus / Alertmanager / Grafana + 3 Exporter) |
| `prometheus/prometheus.yml` | scrape 設定 — api:8000/metrics · postgres · redis · node を 15s 間隔収集 |
| `prometheus/alerts.yml` | SLO アラート 9種 (5xx率>2% / P95>1s / API Down / PostgreSQL / Disk) |
| `prometheus/alertmanager.yml` | critical→on-call / warning→default ルーティング + inhibit_rules |
| `grafana/provisioning/datasources/prometheus.yml` | Prometheus データソース自動登録 |
| `grafana/provisioning/dashboards/dashboards.yml` | ダッシュボード自動プロビジョニング設定 |
| `grafana/dashboards/servicehub-api.json` | 8パネルダッシュボード (RPS/ErrorRate/P95/InFlight + 時系列4枚, 30s auto-refresh) |

### 修正ファイル

| ファイル | 変更 |
|---|---|
| `Makefile` | `monitoring-up` / `monitoring-down` / `monitoring-logs` ターゲット追加 |
| `README.md` | 監視スタックセクション追加 / ロードマップ Phase 9 更新 / Phase 8 STABLE完了 v0.8.1 反映 |
| `state.json` | Phase 9a 開始状態に更新 |

## 起動方法

```bash
# メインスタックと監視スタックをオーバーレイ起動
make monitoring-up

# アクセス先
# Grafana:      http://localhost:3001 (admin/admin)
# Prometheus:   http://localhost:9090
# Alertmanager: http://localhost:9093
```

## Grafana ダッシュボード構成

- **Stat パネル ×4**: Request Rate (RPS) / Error Rate (5xx) / P95 Latency / Active Connections
- **Time series ×4**: Endpoint 別 RPS / P50-P95-P99 レイテンシ / HTTP ステータス分布 / メモリ使用量
- SLO 閾値ライン: P95 < 300ms (green) / < 1s (yellow) / >= 1s (red)

## テスト結果

- `docker compose -f docker-compose.monitoring.yml config --quiet` — YAML 検証 PASS（obsolete 警告なし）
- ネットワーク: `servicehub-net: external: true` で main compose との連携確認済み
- 環境変数: `POSTGRES_USER/PASSWORD/DB` は main compose の設定と一致

## 影響範囲

- **メインスタックへの影響なし**（`docker-compose.monitoring.yml` は独立 overlay）
- `Makefile` / `README.md` は後方互換

## 残課題

- Phase 9b: k6 負荷試験シナリオ拡充 + SLO 基準明文化 (Issue #166)
- Phase 9c: Kubernetes Helm chart 骨格 (Issue #167)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**新機能**
- 監視スタック（Prometheus、Grafana、Alertmanager）を追加し、APIとインフラのメトリクスを可視化
- ServiceHub APIダッシュボードを実装し、リアルタイムパフォーマンス監視が可能に
- システムアラート機能を実装し、重大度別の通知に対応

**ドキュメント**
- 監視スタックの運用ガイドとセットアップ手順を追加

<!-- end of auto-generated comment: release notes by coderabbit.ai -->