### PR TITLE
feat(phase9c): Kubernetes Helm chart 骨格実装 (Closes #167)

### DIFF
--- a/.github/workflows/helm-lint.yml
+++ b/.github/workflows/helm-lint.yml
@@ -1,0 +1,85 @@
+name: Helm Lint (Phase 9c)
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "charts/**"
+      - ".github/workflows/helm-lint.yml"
+  pull_request:
+    paths:
+      - "charts/**"
+      - ".github/workflows/helm-lint.yml"
+  workflow_dispatch:
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  helm-lint:
+    name: Helm Lint & Template
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: "v3.14.4"
+
+      - name: Add Bitnami repo
+        run: helm repo add bitnami https://charts.bitnami.com/bitnami && helm repo update
+
+      - name: Helm dependency update
+        run: helm dependency update charts/servicehub/
+
+      - name: Helm lint (default values)
+        run: helm lint charts/servicehub/ --strict
+
+      - name: Helm lint (production-like overrides)
+        env:
+          DUMMY_SECRET: "ci-dummy-secret"
+          DUMMY_DB_URL: "postgresql+asyncpg://user:pass@host:5432/db"
+          DUMMY_REDIS_URL: "redis://host:6379/0"
+        run: |
+          helm lint charts/servicehub/ \
+            --set backend.replicaCount=3 \
+            --set "backend.secret.jwtSecretKey=$DUMMY_SECRET" \
+            --set "backend.secret.databaseUrl=$DUMMY_DB_URL" \
+            --set "backend.secret.redisUrl=$DUMMY_REDIS_URL" \
+            --set "ingress.hosts[0].host=servicehub.example.com"
+
+      - name: Helm template (verify manifest generation)
+        env:
+          DUMMY_SECRET: "ci-dummy-secret"
+          DUMMY_DB_URL: "postgresql+asyncpg://user:pass@host:5432/db"
+          DUMMY_REDIS_URL: "redis://host:6379/0"
+        run: |
+          helm template servicehub charts/servicehub/ \
+            --set "backend.secret.jwtSecretKey=$DUMMY_SECRET" \
+            --set "backend.secret.databaseUrl=$DUMMY_DB_URL" \
+            --set "backend.secret.redisUrl=$DUMMY_REDIS_URL" \
+            > /tmp/servicehub-manifests.yaml
+          echo "--- Generated resources ---"
+          grep "^kind:" /tmp/servicehub-manifests.yaml | sort | uniq -c | sort -rn
+
+      - name: Upload rendered manifests
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: helm-manifests
+          path: /tmp/servicehub-manifests.yaml
+          retention-days: 30
+
+      - name: Validate Kubernetes manifests (kubeconform)
+        run: |
+          curl -sSLo /tmp/kubeconform.tar.gz \
+            https://github.com/yannh/kubeconform/releases/download/v0.6.7/kubeconform-linux-amd64.tar.gz
+          tar -xzf /tmp/kubeconform.tar.gz -C /tmp
+          chmod +x /tmp/kubeconform
+          /tmp/kubeconform \
+            -summary \
+            -ignore-missing-schemas \
+            -kubernetes-version 1.29.0 \
+            /tmp/servicehub-manifests.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,7 @@ logs/
 
 # ── ビルド成果物 ─────────────────────────────────────
 *.pyc
+
+# ── Helm ─────────────────────────────────────────────
+charts/servicehub/charts/*.tgz
+charts/servicehub/Chart.lock

--- a/charts/servicehub/Chart.yaml
+++ b/charts/servicehub/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: servicehub
+description: ServiceHub Construction Platform — full-stack Helm chart
+type: application
+version: 0.1.0
+appVersion: "1.0.0"
+keywords:
+  - servicehub
+  - construction
+  - fastapi
+  - nextjs
+home: https://github.com/Kensan196948G/ServiceHub-Construction-Platform
+maintainers:
+  - name: kensan
+    email: kensan1969@gmail.com
+dependencies:
+  - name: postgresql
+    version: "15.5.x"
+    repository: "https://charts.bitnami.com/bitnami"
+    condition: postgresql.enabled
+  - name: redis
+    version: "19.x.x"
+    repository: "https://charts.bitnami.com/bitnami"
+    condition: redis.enabled

--- a/charts/servicehub/templates/_helpers.tpl
+++ b/charts/servicehub/templates/_helpers.tpl
@@ -1,0 +1,85 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "servicehub.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "servicehub.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart label.
+*/}}
+{{- define "servicehub.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels.
+*/}}
+{{- define "servicehub.labels" -}}
+helm.sh/chart: {{ include "servicehub.chart" . }}
+{{ include "servicehub.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels.
+*/}}
+{{- define "servicehub.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "servicehub.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+ServiceAccount name.
+*/}}
+{{- define "servicehub.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "servicehub.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Backend full name.
+*/}}
+{{- define "servicehub.backend.fullname" -}}
+{{- printf "%s-backend" (include "servicehub.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Frontend full name.
+*/}}
+{{- define "servicehub.frontend.fullname" -}}
+{{- printf "%s-frontend" (include "servicehub.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Namespace name.
+*/}}
+{{- define "servicehub.namespace" -}}
+{{- if .Values.namespace.create -}}
+{{- .Values.namespace.name | default "servicehub" }}
+{{- else -}}
+{{- .Release.Namespace }}
+{{- end }}
+{{- end }}

--- a/charts/servicehub/templates/backend-deployment.yaml
+++ b/charts/servicehub/templates/backend-deployment.yaml
@@ -1,0 +1,86 @@
+{{- if .Values.backend.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "servicehub.backend.fullname" . }}
+  namespace: {{ include "servicehub.namespace" . }}
+  labels:
+    {{- include "servicehub.labels" . | nindent 4 }}
+    app.kubernetes.io/component: backend
+spec:
+  {{- if not .Values.backend.autoscaling.enabled }}
+  replicas: {{ .Values.backend.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "servicehub.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: backend
+  template:
+    metadata:
+      labels:
+        {{- include "servicehub.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: backend
+    spec:
+      serviceAccountName: {{ include "servicehub.serviceAccountName" . }}
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        fsGroup: 1000
+      containers:
+        - name: backend
+          image: "{{ .Values.backend.image.repository }}:{{ .Values.backend.image.tag }}"
+          imagePullPolicy: {{ .Values.backend.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 8000
+              protocol: TCP
+          envFrom:
+            - configMapRef:
+                name: {{ include "servicehub.backend.fullname" . }}-config
+          {{- if or .Values.backend.secret.jwtSecretKey .Values.backend.secret.databaseUrl .Values.backend.secret.redisUrl }}
+          env:
+            {{- if .Values.backend.secret.jwtSecretKey }}
+            - name: JWT_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "servicehub.backend.fullname" . }}-secret
+                  key: JWT_SECRET_KEY
+            {{- end }}
+            {{- if .Values.backend.secret.databaseUrl }}
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "servicehub.backend.fullname" . }}-secret
+                  key: DATABASE_URL
+            {{- end }}
+            {{- if .Values.backend.secret.redisUrl }}
+            - name: REDIS_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "servicehub.backend.fullname" . }}-secret
+                  key: REDIS_URL
+            {{- end }}
+          {{- end }}
+          livenessProbe:
+            {{- toYaml .Values.backend.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.backend.readinessProbe | nindent 12 }}
+          resources:
+            {{- toYaml .Values.backend.resources | nindent 12 }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/servicehub/templates/backend-service.yaml
+++ b/charts/servicehub/templates/backend-service.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.backend.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "servicehub.backend.fullname" . }}
+  namespace: {{ include "servicehub.namespace" . }}
+  labels:
+    {{- include "servicehub.labels" . | nindent 4 }}
+    app.kubernetes.io/component: backend
+spec:
+  type: {{ .Values.backend.service.type }}
+  ports:
+    - port: {{ .Values.backend.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "servicehub.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: backend
+{{- end }}

--- a/charts/servicehub/templates/configmap.yaml
+++ b/charts/servicehub/templates/configmap.yaml
@@ -1,0 +1,38 @@
+{{- if .Values.backend.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "servicehub.backend.fullname" . }}-config
+  namespace: {{ include "servicehub.namespace" . }}
+  labels:
+    {{- include "servicehub.labels" . | nindent 4 }}
+    app.kubernetes.io/component: backend
+data:
+  ENVIRONMENT: {{ .Values.backend.env.ENVIRONMENT | quote }}
+  JWT_ALGORITHM: {{ .Values.backend.env.JWT_ALGORITHM | quote }}
+  LOG_LEVEL: {{ .Values.backend.env.LOG_LEVEL | quote }}
+  {{- if .Values.postgresql.enabled }}
+  POSTGRES_HOST: {{ printf "%s-postgresql" .Release.Name | quote }}
+  POSTGRES_PORT: "5432"
+  POSTGRES_DB: {{ .Values.postgresql.auth.database | quote }}
+  POSTGRES_USER: {{ .Values.postgresql.auth.username | quote }}
+  {{- end }}
+  {{- if .Values.redis.enabled }}
+  REDIS_HOST: {{ printf "%s-redis-master" .Release.Name | quote }}
+  REDIS_PORT: "6379"
+  {{- end }}
+{{- end }}
+---
+{{- if .Values.frontend.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "servicehub.frontend.fullname" . }}-config
+  namespace: {{ include "servicehub.namespace" . }}
+  labels:
+    {{- include "servicehub.labels" . | nindent 4 }}
+    app.kubernetes.io/component: frontend
+data:
+  NEXT_PUBLIC_API_URL: {{ .Values.frontend.env.NEXT_PUBLIC_API_URL | quote }}
+  NODE_ENV: {{ .Values.frontend.env.NODE_ENV | quote }}
+{{- end }}

--- a/charts/servicehub/templates/frontend-deployment.yaml
+++ b/charts/servicehub/templates/frontend-deployment.yaml
@@ -1,0 +1,56 @@
+{{- if .Values.frontend.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "servicehub.frontend.fullname" . }}
+  namespace: {{ include "servicehub.namespace" . }}
+  labels:
+    {{- include "servicehub.labels" . | nindent 4 }}
+    app.kubernetes.io/component: frontend
+spec:
+  {{- if not .Values.frontend.autoscaling.enabled }}
+  replicas: {{ .Values.frontend.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "servicehub.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: frontend
+  template:
+    metadata:
+      labels:
+        {{- include "servicehub.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: frontend
+    spec:
+      serviceAccountName: {{ include "servicehub.serviceAccountName" . }}
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1001
+        fsGroup: 1001
+      containers:
+        - name: frontend
+          image: "{{ .Values.frontend.image.repository }}:{{ .Values.frontend.image.tag }}"
+          imagePullPolicy: {{ .Values.frontend.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 3000
+              protocol: TCP
+          envFrom:
+            - configMapRef:
+                name: {{ include "servicehub.frontend.fullname" . }}-config
+          livenessProbe:
+            {{- toYaml .Values.frontend.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.frontend.readinessProbe | nindent 12 }}
+          resources:
+            {{- toYaml .Values.frontend.resources | nindent 12 }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: false
+            capabilities:
+              drop:
+                - ALL
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/servicehub/templates/frontend-service.yaml
+++ b/charts/servicehub/templates/frontend-service.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.frontend.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "servicehub.frontend.fullname" . }}
+  namespace: {{ include "servicehub.namespace" . }}
+  labels:
+    {{- include "servicehub.labels" . | nindent 4 }}
+    app.kubernetes.io/component: frontend
+spec:
+  type: {{ .Values.frontend.service.type }}
+  ports:
+    - port: {{ .Values.frontend.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "servicehub.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: frontend
+{{- end }}

--- a/charts/servicehub/templates/hpa.yaml
+++ b/charts/servicehub/templates/hpa.yaml
@@ -1,0 +1,83 @@
+{{- if and .Values.backend.enabled .Values.backend.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "servicehub.backend.fullname" . }}
+  namespace: {{ include "servicehub.namespace" . }}
+  labels:
+    {{- include "servicehub.labels" . | nindent 4 }}
+    app.kubernetes.io/component: backend
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "servicehub.backend.fullname" . }}
+  minReplicas: {{ .Values.backend.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.backend.autoscaling.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.backend.autoscaling.targetCPUUtilizationPercentage }}
+    {{- if .Values.backend.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.backend.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+  behavior:
+    scaleDown:
+      stabilizationWindowSeconds: 300
+      policies:
+        - type: Pods
+          value: 1
+          periodSeconds: 60
+    scaleUp:
+      stabilizationWindowSeconds: 60
+      policies:
+        - type: Pods
+          value: 2
+          periodSeconds: 60
+{{- end }}
+---
+{{- if and .Values.frontend.enabled .Values.frontend.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "servicehub.frontend.fullname" . }}
+  namespace: {{ include "servicehub.namespace" . }}
+  labels:
+    {{- include "servicehub.labels" . | nindent 4 }}
+    app.kubernetes.io/component: frontend
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "servicehub.frontend.fullname" . }}
+  minReplicas: {{ .Values.frontend.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.frontend.autoscaling.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.frontend.autoscaling.targetCPUUtilizationPercentage }}
+  behavior:
+    scaleDown:
+      stabilizationWindowSeconds: 300
+      policies:
+        - type: Pods
+          value: 1
+          periodSeconds: 60
+    scaleUp:
+      stabilizationWindowSeconds: 60
+      policies:
+        - type: Pods
+          value: 1
+          periodSeconds: 60
+{{- end }}

--- a/charts/servicehub/templates/ingress.yaml
+++ b/charts/servicehub/templates/ingress.yaml
@@ -1,0 +1,48 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "servicehub.fullname" . }}
+  namespace: {{ include "servicehub.namespace" . }}
+  labels:
+    {{- include "servicehub.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                {{- if eq .service "backend" }}
+                name: {{ include "servicehub.backend.fullname" $ }}
+                port:
+                  number: {{ $.Values.backend.service.port }}
+                {{- else }}
+                name: {{ include "servicehub.frontend.fullname" $ }}
+                port:
+                  number: {{ $.Values.frontend.service.port }}
+                {{- end }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/servicehub/templates/namespace.yaml
+++ b/charts/servicehub/templates/namespace.yaml
@@ -1,0 +1,8 @@
+{{- if .Values.namespace.create }}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ include "servicehub.namespace" . }}
+  labels:
+    {{- include "servicehub.labels" . | nindent 4 }}
+{{- end }}

--- a/charts/servicehub/templates/rbac.yaml
+++ b/charts/servicehub/templates/rbac.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "servicehub.fullname" . }}
+  namespace: {{ include "servicehub.namespace" . }}
+  labels:
+    {{- include "servicehub.labels" . | nindent 4 }}
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps", "secrets"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "servicehub.fullname" . }}
+  namespace: {{ include "servicehub.namespace" . }}
+  labels:
+    {{- include "servicehub.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "servicehub.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "servicehub.serviceAccountName" . }}
+    namespace: {{ include "servicehub.namespace" . }}
+{{- end }}

--- a/charts/servicehub/templates/secret.yaml
+++ b/charts/servicehub/templates/secret.yaml
@@ -1,0 +1,27 @@
+{{- if .Values.backend.enabled }}
+{{- if or .Values.backend.secret.jwtSecretKey .Values.backend.secret.databaseUrl .Values.backend.secret.redisUrl }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "servicehub.backend.fullname" . }}-secret
+  namespace: {{ include "servicehub.namespace" . }}
+  labels:
+    {{- include "servicehub.labels" . | nindent 4 }}
+    app.kubernetes.io/component: backend
+  annotations:
+    # In production, manage secrets with sealed-secrets or external-secrets-operator.
+    # Never commit plaintext secret values to git.
+    helm.sh/resource-policy: keep
+type: Opaque
+data:
+  {{- if .Values.backend.secret.jwtSecretKey }}
+  JWT_SECRET_KEY: {{ .Values.backend.secret.jwtSecretKey | b64enc | quote }}
+  {{- end }}
+  {{- if .Values.backend.secret.databaseUrl }}
+  DATABASE_URL: {{ .Values.backend.secret.databaseUrl | b64enc | quote }}
+  {{- end }}
+  {{- if .Values.backend.secret.redisUrl }}
+  REDIS_URL: {{ .Values.backend.secret.redisUrl | b64enc | quote }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/servicehub/templates/serviceaccount.yaml
+++ b/charts/servicehub/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "servicehub.serviceAccountName" . }}
+  namespace: {{ include "servicehub.namespace" . }}
+  labels:
+    {{- include "servicehub.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/servicehub/values.yaml
+++ b/charts/servicehub/values.yaml
@@ -1,0 +1,185 @@
+# Default values for servicehub Helm chart.
+# Override with -f values-production.yaml or --set key=value
+
+# ── Global ────────────────────────────────────────────────────────────
+global:
+  imageRegistry: ""
+  imagePullSecrets: []
+  storageClass: ""
+
+# ── Backend (FastAPI) ─────────────────────────────────────────────────
+backend:
+  enabled: true
+  replicaCount: 2
+  image:
+    repository: ghcr.io/kensan196948g/servicehub-construction-platform/backend
+    tag: "latest"
+    pullPolicy: IfNotPresent
+
+  service:
+    type: ClusterIP
+    port: 8000
+
+  resources:
+    requests:
+      cpu: "250m"
+      memory: "256Mi"
+    limits:
+      cpu: "1000m"
+      memory: "1Gi"
+
+  autoscaling:
+    enabled: true
+    minReplicas: 2
+    maxReplicas: 10
+    targetCPUUtilizationPercentage: 70
+    targetMemoryUtilizationPercentage: 80
+
+  livenessProbe:
+    httpGet:
+      path: /health/live
+      port: 8000
+    initialDelaySeconds: 15
+    periodSeconds: 10
+    failureThreshold: 3
+
+  readinessProbe:
+    httpGet:
+      path: /health/ready
+      port: 8000
+    initialDelaySeconds: 10
+    periodSeconds: 5
+    failureThreshold: 3
+
+  env:
+    ENVIRONMENT: "production"
+    JWT_ALGORITHM: "HS256"
+    LOG_LEVEL: "INFO"
+
+  # Secret keys — override with sealed-secrets or external-secrets in production
+  secret:
+    jwtSecretKey: ""       # required: set via --set or external secret
+    databaseUrl: ""        # required: set via --set or external secret
+    redisUrl: ""           # required: set via --set or external secret
+
+# ── Frontend (Next.js) ────────────────────────────────────────────────
+frontend:
+  enabled: true
+  replicaCount: 2
+  image:
+    repository: ghcr.io/kensan196948g/servicehub-construction-platform/frontend
+    tag: "latest"
+    pullPolicy: IfNotPresent
+
+  service:
+    type: ClusterIP
+    port: 3000
+
+  resources:
+    requests:
+      cpu: "100m"
+      memory: "128Mi"
+    limits:
+      cpu: "500m"
+      memory: "512Mi"
+
+  autoscaling:
+    enabled: true
+    minReplicas: 2
+    maxReplicas: 6
+    targetCPUUtilizationPercentage: 70
+
+  livenessProbe:
+    httpGet:
+      path: /api/health
+      port: 3000
+    initialDelaySeconds: 20
+    periodSeconds: 15
+    failureThreshold: 3
+
+  readinessProbe:
+    httpGet:
+      path: /api/health
+      port: 3000
+    initialDelaySeconds: 15
+    periodSeconds: 5
+    failureThreshold: 3
+
+  env:
+    NEXT_PUBLIC_API_URL: "http://servicehub-backend:8000"
+    NODE_ENV: "production"
+
+# ── Ingress ───────────────────────────────────────────────────────────
+ingress:
+  enabled: true
+  className: "nginx"
+  annotations:
+    nginx.ingress.kubernetes.io/proxy-body-size: "50m"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "300"
+  hosts:
+    - host: servicehub.example.com
+      paths:
+        - path: /api
+          pathType: Prefix
+          service: backend
+        - path: /docs
+          pathType: Prefix
+          service: backend
+        - path: /
+          pathType: Prefix
+          service: frontend
+  tls:
+    - secretName: servicehub-tls
+      hosts:
+        - servicehub.example.com
+
+# ── PostgreSQL (Bitnami subchart) ─────────────────────────────────────
+postgresql:
+  enabled: true
+  auth:
+    database: servicehub_db
+    username: servicehub
+    # password: set via --set postgresql.auth.password=<val>
+  primary:
+    persistence:
+      enabled: true
+      size: 10Gi
+    resources:
+      requests:
+        cpu: "250m"
+        memory: "256Mi"
+      limits:
+        cpu: "1000m"
+        memory: "1Gi"
+
+# ── Redis (Bitnami subchart) ──────────────────────────────────────────
+redis:
+  enabled: true
+  architecture: standalone
+  auth:
+    enabled: false
+  master:
+    persistence:
+      enabled: true
+      size: 2Gi
+    resources:
+      requests:
+        cpu: "100m"
+        memory: "128Mi"
+      limits:
+        cpu: "500m"
+        memory: "256Mi"
+
+# ── RBAC ──────────────────────────────────────────────────────────────
+rbac:
+  create: true
+
+serviceAccount:
+  create: true
+  name: ""
+  annotations: {}
+
+# ── Namespace ─────────────────────────────────────────────────────────
+namespace:
+  create: true
+  name: "servicehub"

--- a/docs/deployment/kubernetes.md
+++ b/docs/deployment/kubernetes.md
@@ -1,0 +1,191 @@
+# Kubernetes デプロイメントガイド — ServiceHub Construction Platform
+
+## 概要
+
+ServiceHub は Helm chart (`charts/servicehub/`) で Kubernetes クラスタへデプロイできます。
+Docker Compose（開発・ステージング）と並行する本番マイグレーションパスとして提供します。
+
+## 前提条件
+
+| ツール | バージョン | 用途 |
+|---|---|---|
+| kubectl | >= 1.29 | クラスタ操作 |
+| helm | >= 3.14 | チャート管理 |
+| Docker | 任意 | イメージビルド |
+| k8s クラスタ | >= 1.29 | デプロイ先（EKS/GKE/AKS/kind） |
+
+## アーキテクチャ
+
+```
+Ingress (nginx)
+    ├── /         → frontend (Next.js, port 3000)
+    ├── /api      → backend  (FastAPI,  port 8000)
+    └── /docs     → backend  (FastAPI OpenAPI)
+
+backend ──── PostgreSQL (Bitnami subchart, port 5432)
+         └── Redis      (Bitnami subchart, port 6379)
+```
+
+## クイックスタート
+
+### 1. 依存チャートのダウンロード
+
+```bash
+helm repo add bitnami https://charts.bitnami.com/bitnami
+helm repo update
+helm dependency update charts/servicehub/
+```
+
+### 2. lint 確認
+
+```bash
+helm lint charts/servicehub/ --strict
+```
+
+### 3. シークレット準備
+
+```bash
+# 本番では sealed-secrets または external-secrets-operator を推奨
+JWT_SECRET=$(openssl rand -hex 32)
+DB_PASSWORD=$(openssl rand -hex 16)
+```
+
+### 4. インストール
+
+```bash
+helm install servicehub charts/servicehub/ \
+  --namespace servicehub \
+  --create-namespace \
+  --set backend.secret.jwtSecretKey="${JWT_SECRET}" \
+  --set backend.secret.databaseUrl="postgresql+asyncpg://servicehub:${DB_PASSWORD}@servicehub-postgresql:5432/servicehub_db" \
+  --set backend.secret.redisUrl="redis://servicehub-redis-master:6379/0" \
+  --set postgresql.auth.password="${DB_PASSWORD}" \
+  --set ingress.hosts[0].host="servicehub.yourdomain.com" \
+  --wait
+```
+
+### 5. マイグレーション実行
+
+```bash
+kubectl exec -n servicehub deploy/servicehub-backend -- alembic upgrade head
+```
+
+## 環境別値ファイル
+
+```bash
+# ステージング
+helm upgrade --install servicehub charts/servicehub/ \
+  -f charts/servicehub/values.yaml \
+  -f values-staging.yaml \
+  --namespace servicehub-staging
+
+# 本番
+helm upgrade --install servicehub charts/servicehub/ \
+  -f charts/servicehub/values.yaml \
+  -f values-production.yaml \
+  --namespace servicehub
+```
+
+### values-production.yaml の例
+
+```yaml
+backend:
+  replicaCount: 3
+  autoscaling:
+    enabled: true
+    minReplicas: 3
+    maxReplicas: 20
+
+frontend:
+  replicaCount: 3
+  autoscaling:
+    enabled: true
+    minReplicas: 2
+    maxReplicas: 8
+
+postgresql:
+  primary:
+    persistence:
+      size: 50Gi
+
+ingress:
+  hosts:
+    - host: servicehub.yourdomain.com
+      paths:
+        - path: /api
+          pathType: Prefix
+          service: backend
+        - path: /docs
+          pathType: Prefix
+          service: backend
+        - path: /
+          pathType: Prefix
+          service: frontend
+  tls:
+    - secretName: servicehub-tls
+      hosts:
+        - servicehub.yourdomain.com
+```
+
+## HPA (水平スケール)
+
+| コンポーネント | min | max | CPU閾値 |
+|---|---|---|---|
+| backend | 2 | 10 | 70% |
+| frontend | 2 | 6 | 70% |
+
+```bash
+# HPA 状態確認
+kubectl get hpa -n servicehub
+```
+
+## 操作コマンド
+
+```bash
+# ステータス確認
+helm status servicehub -n servicehub
+kubectl get all -n servicehub
+
+# ログ確認
+kubectl logs -n servicehub -l app.kubernetes.io/component=backend -f
+
+# ロールバック
+helm rollback servicehub 0 -n servicehub  # 0 = 1つ前のリビジョン
+
+# アンインストール
+helm uninstall servicehub -n servicehub
+```
+
+## ローカル検証 (kind)
+
+```bash
+# kind クラスタ作成
+kind create cluster --name servicehub-dev
+
+# ingress-nginx インストール
+kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/main/deploy/static/provider/kind/deploy.yaml
+
+# デプロイ
+helm install servicehub charts/servicehub/ \
+  --set backend.secret.jwtSecretKey="dev-secret" \
+  --set backend.secret.databaseUrl="postgresql+asyncpg://servicehub:pass@servicehub-postgresql:5432/servicehub_db" \
+  --set backend.secret.redisUrl="redis://servicehub-redis-master:6379/0" \
+  --set postgresql.auth.password="pass" \
+  --set ingress.hosts[0].host="localhost"
+```
+
+## セキュリティ
+
+- backend コンテナは `readOnlyRootFilesystem: true` + `runAsNonRoot: true`
+- シークレットは `helm install --set` ではなく sealed-secrets / ESO を本番推奨
+- RBAC は `Role` + `RoleBinding`（namespace スコープ）のみ付与
+- HPA の scaleDown には 5 分の stabilization window を設定（フラッピング防止）
+
+## CI/CD 統合
+
+GitHub Actions で `helm-lint.yml` が以下を自動実行:
+
+1. `helm lint --strict`
+2. `helm template` でマニフェスト生成
+3. `kubeconform` で Kubernetes API バリデーション
+4. 生成マニフェストを artifact アップロード


### PR DESCRIPTION
## 変更内容

Phase 9c: Docker Compose → Kubernetes マイグレーションパス整備

### 追加ファイル

| ファイル | 役割 |
|---|---|
| `charts/servicehub/Chart.yaml` | Helm chart メタデータ、Bitnami deps (PostgreSQL/Redis) |
| `charts/servicehub/values.yaml` | 環境別設定の単一真実ソース (backend/frontend/HPA/ingress/RBAC) |
| `templates/_helpers.tpl` | 共通ラベル・名前生成ヘルパー |
| `templates/backend-deployment.yaml` | FastAPI Deployment (readOnlyRootFilesystem, runAsNonRoot) |
| `templates/frontend-deployment.yaml` | Next.js Deployment |
| `templates/backend-service.yaml` / `frontend-service.yaml` | ClusterIP Services |
| `templates/hpa.yaml` | HPA v2 (CPU > 70% でスケールアウト、backend 2-10pod / frontend 2-6pod) |
| `templates/ingress.yaml` | nginx Ingress (path-based routing: / → frontend, /api → backend) |
| `templates/configmap.yaml` | 非機密環境変数 |
| `templates/secret.yaml` | JWT/DB/Redis シークレット（本番では sealed-secrets 推奨） |
| `templates/rbac.yaml` | Role + RoleBinding（namespace スコープ最小権限） |
| `templates/namespace.yaml` / `serviceaccount.yaml` | namespace・SA 管理 |
| `.github/workflows/helm-lint.yml` | CI: helm lint + helm template + kubeconform |
| `docs/deployment/kubernetes.md` | デプロイ手順書（kind ローカル検証手順含む） |

## テスト結果

```
helm lint charts/servicehub/ --strict
→ 1 chart(s) linted, 0 chart(s) failed ✅

helm template で生成:
  Deployment × 2, Service × 6, HPA × 2, Ingress × 1,
  ConfigMap × 5, Secret × 2, NetworkPolicy × 2,
  PodDisruptionBudget × 2, RBAC × 2, Namespace × 1 ✅
```

## 受け入れ条件 (Issue #167)

- [x] helm lint 通過
- [x] helm template で YAML 生成確認
- [x] docs/deployment/kubernetes.md 作成
- [x] CI: helm lint ジョブ追加 (helm-lint.yml)

## 影響範囲

- 新規ディレクトリ (`charts/`, `docs/deployment/`) のみ追加
- 既存コード・CI への変更なし

## 残課題

- values-production.yaml / values-staging.yaml の実環境への書き込み（本番 k8s クラスタ確定後）
- sealed-secrets / external-secrets-operator 統合（Phase 10 候補）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **New Features**
  * ServiceHub の Helm チャートを追加し、バックエンド・フロントエンド、PostgreSQL、Redis を含む本番向け Kubernetes デプロイをサポート。
  * Ingress、Service、Deployments、ConfigMap、Secret、ServiceAccount、Namespace、RBAC、HPA による自動スケーリングとセキュリティ設定を提供。
  * デフォルト設定と可変値を備えた values.yaml を追加。

* **Documentation**
  * Helm を使った Kubernetes デプロイ手順と運用ガイドを追加。

* **Chores**
  * CI に Helm lint/template 実行、マニフェスト生成のアーティファクト保存、マニフェスト検証を追加。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->