### PR TITLE
docs(phase10b): ユーザードキュメント整備 + OpenAPI description 拡充

### DIFF
--- a/README.md
+++ b/README.md
@@ -763,6 +763,20 @@ helm install servicehub charts/servicehub/ \
 
 ---
 
+## 📚 ユーザードキュメント
+
+| ガイド | 対象 |
+|---|---|
+| [はじめに（5分セットアップ）](docs/user-guide/getting-started.md) | 全ユーザー |
+| [工事案件管理ガイド](docs/user-guide/construction-projects.md) | 現場担当者・PM |
+| [管理者設定ガイド](docs/user-guide/admin-guide.md) | システム管理者 |
+| [Kubernetes デプロイメント](docs/deployment/kubernetes.md) | DevOps・インフラ担当 |
+| [SLO 定義](docs/design/slo.md) | 運用担当 |
+
+API ドキュメント（Swagger UI）: `http://localhost/api/v1/docs`
+
+---
+
 ## 🤝 コントリビューション
 
 1. `main` ブランチへの直接 push は禁止

--- a/backend/app/api/v1/auth.py
+++ b/backend/app/api/v1/auth.py
@@ -41,7 +41,13 @@ async def login(
     payload: LoginRequest,
     db: Annotated[AsyncSession, Depends(get_db)],
 ):
-    """ログイン - JWT発行 (LOGIN_RATE_LIMIT 環境変数で制御、デフォルト 5 回/分)"""
+    """ログイン — JWT アクセストークンとリフレッシュトークンを発行します。
+
+    - アクセストークン有効期限: 15 分（`ACCESS_TOKEN_EXPIRE_MINUTES` で変更可）
+    - リフレッシュトークン有効期限: 7 日（`REFRESH_TOKEN_EXPIRE_DAYS` で変更可）
+    - レート制限: デフォルト 5 回/分（`LOGIN_RATE_LIMIT` 環境変数で変更可）
+    - 無効な資格情報は 401、無効なロールは 403 を返します
+    """
     service = AuthService(db)
     try:
         return await service.login(payload)
@@ -64,7 +70,11 @@ async def refresh_token(
     payload: RefreshRequest,
     db: Annotated[AsyncSession, Depends(get_db)],
 ):
-    """リフレッシュトークンで新アクセストークンを発行 (10 回/分のレート制限あり)"""
+    """リフレッシュトークンで新しいアクセストークンを発行します。
+
+    - 有効なリフレッシュトークンが必要です（ログアウト済みのトークンは 401）
+    - レート制限: 10 回/分（`REFRESH_RATE_LIMIT` 環境変数で変更可）
+    """
     service = AuthService(db)
     try:
         return await service.refresh(payload.refresh_token)

--- a/backend/app/api/v1/routers/costs.py
+++ b/backend/app/api/v1/routers/costs.py
@@ -41,6 +41,12 @@ async def create_cost_record(
         ),
     ],
 ):
+    """原価記録を新規作成します。
+
+    - `category`: `materials` / `labor` / `equipment` / `subcontract` / `other`
+    - `amount`: 税込金額（円、正の整数）
+    - 権限: COST_MANAGER 以上
+    """
     svc = CostService(db)
     data = await svc.create_record(project_id, payload, created_by=current_user.id)
     return ApiResponse(data=data)
@@ -93,7 +99,11 @@ async def get_cost_summary(
         ),
     ],
 ):
-    """予実対比サマリー"""
+    """案件の予実対比サマリーを取得します。
+
+    予算総額・実績合計・差異・進捗率をカテゴリ別に集計して返します。
+    権限: COST_MANAGER 以上
+    """
     svc = CostService(db)
     summary = await svc.get_summary(project_id)
     return ApiResponse(data=summary)

--- a/backend/app/api/v1/routers/projects.py
+++ b/backend/app/api/v1/routers/projects.py
@@ -45,6 +45,13 @@ async def list_projects(
     per_page: int = Query(default=20, ge=1, le=100),
     filter_status: str | None = Query(default=None, alias="status"),
 ):
+    """工事案件一覧を取得します（ページネーション付き）。
+
+    - `status` フィルター: `planning` / `active` / `on_hold` / `completed` / `cancelled`
+    - `per_page` 最大値: 100
+    - 論理削除済み案件は含まれません
+    - 権限: VIEWER 以上
+    """
     svc = ProjectService(db)
     projects, total = await svc.list_projects(page, per_page, status=filter_status)
     return PaginatedResponse(
@@ -68,6 +75,12 @@ async def create_project(
         User, Depends(require_roles(UserRole.ADMIN, UserRole.PROJECT_MANAGER))
     ],
 ):
+    """新しい工事案件を作成します。
+
+    - `project_code` は一意である必要があります（重複時は 409）
+    - 初期ステータスは `planning` または `active` を推奨
+    - 権限: PROJECT_MANAGER 以上
+    """
     svc = ProjectService(db)
     project = await svc.create_project(payload, created_by=current_user.id)
     return ApiResponse(data=project)

--- a/backend/app/api/v1/routers/safety.py
+++ b/backend/app/api/v1/routers/safety.py
@@ -40,6 +40,12 @@ async def create_safety_check(
         ),
     ],
 ):
+    """安全確認チェックリストを記録します。
+
+    - 1 日 1 案件につき複数回記録可能
+    - `items`: チェック項目ごとに `category`, `checked` (bool), `note` を含む配列
+    - 権限: SITE_SUPERVISOR 以上
+    """
     svc = SafetyService(db)
     data = await svc.create_safety_check(
         project_id, payload, created_by=current_user.id

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -95,7 +95,47 @@ async def lifespan(app: FastAPI):  # type: ignore[override]
 
 app = FastAPI(
     title=settings.APP_NAME + " API",
-    description="建設業向けAI統合業務プラットフォーム",
+    description="""
+建設業向け AI 統合業務プラットフォーム
+
+## 認証
+
+全ての API は Bearer トークン認証が必要です（ヘルスチェック系を除く）。
+
+```
+POST /api/v1/auth/login  → { access_token, refresh_token }
+Authorization: Bearer {access_token}
+```
+
+アクセストークンの有効期限は 15 分です。
+期限切れ後は `/auth/refresh` で再取得してください。
+
+## ロール・権限
+
+| ロール | 説明 |
+|---|---|
+| `admin` | 全操作 + ユーザー管理 |
+| `project_manager` | 案件CRUD・承認 |
+| `site_supervisor` | 日報・安全確認 |
+| `cost_manager` | 原価管理 |
+| `it_operator` | ITSM・ナレッジ |
+| `viewer` | 読み取りのみ |
+
+## エラーレスポンス
+
+全エラーは以下の形式で返されます:
+
+```json
+{ "success": false, "error": { "code": "ERROR_CODE", "message": "説明" } }
+```
+
+## レート制限
+
+- ログイン: 5 回/分
+- トークンリフレッシュ: 10 回/分
+
+制限超過時は HTTP 429 が返されます。
+""",
     version=settings.APP_VERSION,
     docs_url="/docs",
     redoc_url="/redoc",

--- a/docs/user-guide/admin-guide.md
+++ b/docs/user-guide/admin-guide.md
@@ -1,0 +1,175 @@
+# 管理者設定ガイド
+
+システム管理者（`ADMIN` ロール）向けの初期設定・ユーザー管理・運用設定を説明します。
+
+## ロール一覧と権限
+
+| ロール | 説明 | 主な権限 |
+|---|---|---|
+| `ADMIN` | システム管理者 | 全操作 + ユーザー管理 |
+| `PROJECT_MANAGER` | 工事管理者 | 案件CRUD・承認・全日報閲覧 |
+| `SITE_SUPERVISOR` | 現場監督 | 日報作成・安全確認 |
+| `COST_MANAGER` | 原価管理者 | 原価記録・予実サマリー |
+| `IT_OPERATOR` | IT運用担当 | ITSM操作・ナレッジ管理 |
+| `VIEWER` | 閲覧者 | 全データの読み取りのみ |
+
+> **SoD（職務分離）**: `COST_MANAGER` は変更要求の承認ができません。`PROJECT_MANAGER` が原価入力はできません。これは ISO 20000 準拠の設計です。
+
+## 1. 初期ユーザー設定
+
+### 管理者アカウントの確認
+
+```bash
+docker compose exec backend python -c "
+import asyncio
+from app.db.session import AsyncSessionLocal
+from app.models.user import User
+from sqlalchemy import select
+
+async def check():
+    async with AsyncSessionLocal() as db:
+        users = await db.execute(select(User).where(User.role == 'admin'))
+        for u in users.scalars():
+            print(f'{u.email} ({u.role})')
+
+asyncio.run(check())
+"
+```
+
+### ユーザーの作成
+
+```http
+POST /api/v1/users/
+Authorization: Bearer {admin_access_token}
+Content-Type: application/json
+
+{
+  "email": "manager@example.com",
+  "full_name": "山田 太郎",
+  "password": "SecurePass1234!",
+  "role": "project_manager"
+}
+```
+
+### ユーザーのロール変更
+
+```http
+PATCH /api/v1/users/{user_id}
+Authorization: Bearer {admin_access_token}
+Content-Type: application/json
+
+{
+  "role": "site_supervisor"
+}
+```
+
+## 2. 環境変数による設定
+
+`.env` で以下の項目を管理します:
+
+| 変数名 | デフォルト | 説明 |
+|---|---|---|
+| `JWT_SECRET_KEY` | (必須変更) | JWT署名キー。本番では 64 文字以上のランダム文字列 |
+| `JWT_ALGORITHM` | `HS256` | 署名アルゴリズム |
+| `ACCESS_TOKEN_EXPIRE_MINUTES` | `15` | アクセストークン有効期限（分） |
+| `REFRESH_TOKEN_EXPIRE_DAYS` | `7` | リフレッシュトークン有効期限（日） |
+| `LOGIN_RATE_LIMIT` | `5/minute` | ログインレート制限 |
+| `ALLOWED_ORIGINS` | `http://localhost` | CORS 許可オリジン（カンマ区切り） |
+
+## 3. データベースのバックアップ
+
+### 手動バックアップ
+
+```bash
+docker compose exec db pg_dump -U servicehub servicehub > backup_$(date +%Y%m%d).sql
+```
+
+### リストア
+
+```bash
+docker compose exec -T db psql -U servicehub servicehub < backup_20260425.sql
+```
+
+## 4. 監視の確認
+
+Prometheus + Grafana スタックを使用した監視:
+
+```bash
+# 監視スタック起動
+make monitoring-up
+
+# Grafana ダッシュボード
+open http://localhost:3001  # admin / admin (初回)
+
+# Prometheus メトリクス
+open http://localhost:9090
+
+# Alertmanager
+open http://localhost:9093
+```
+
+> **本番設定**: `monitoring/grafana/` 配下の `grafana.env` で管理者パスワードを変更してください。
+
+## 5. セキュリティ監査ログの確認
+
+全 API 操作は structlog 形式で記録されています:
+
+```bash
+docker compose logs backend | grep '"user_id"' | tail -50
+```
+
+ログ形式:
+```json
+{
+  "timestamp": "2026-04-25T10:00:00Z",
+  "level": "info",
+  "event": "project_created",
+  "user_id": 1,
+  "project_id": 42,
+  "request_id": "abc-123"
+}
+```
+
+## 6. ITSM インシデント・変更要求の管理
+
+### インシデント起票（IT_OPERATOR 以上）
+
+```http
+POST /api/v1/itsm/incidents
+Authorization: Bearer {access_token}
+Content-Type: application/json
+
+{
+  "title": "API応答遅延",
+  "description": "projects エンドポイントで P95 > 2s",
+  "priority": "high",
+  "category": "performance"
+}
+```
+
+### 変更要求の承認（ADMIN のみ）
+
+変更要求の承認は SoD により `ADMIN` のみが実行できます:
+
+```http
+PATCH /api/v1/itsm/changes/{change_id}/approve
+Authorization: Bearer {admin_access_token}
+```
+
+## 7. 秘密情報のローテーション
+
+`docs/security/secret-rotation.md` の手順を参照してください。定期ローテーション推奨サイクル:
+
+| シークレット | ローテーション周期 |
+|---|---|
+| `JWT_SECRET_KEY` | 90 日 |
+| データベースパスワード | 180 日 |
+| MinIO アクセスキー | 180 日 |
+| OpenAI API キー | 漏洩時即時 |
+
+## 関連ドキュメント
+
+- [はじめに](getting-started.md) — 環境構築
+- [工事案件管理ガイド](construction-projects.md) — 案件操作
+- [秘密情報ローテーション手順](../security/secret-rotation.md)
+- [Kubernetes デプロイメント](../deployment/kubernetes.md)

--- a/docs/user-guide/construction-projects.md
+++ b/docs/user-guide/construction-projects.md
@@ -1,0 +1,139 @@
+# 工事案件管理ガイド
+
+工事案件（Construction Project）の作成・更新・ステータス管理の基本操作を説明します。
+
+## 画面構成
+
+| 画面 | URL | 説明 |
+|---|---|---|
+| 案件一覧 | `/projects` | 案件の検索・フィルター・ページネーション |
+| 案件詳細 | `/projects/{id}` | 案件情報・日報・コスト・安全確認 |
+
+## 1. 案件を作成する
+
+### 必須項目
+
+| フィールド | 説明 | 例 |
+|---|---|---|
+| 案件名 | プロジェクト名称 | `渋谷ビル改修工事` |
+| 案件コード | 一意の識別コード | `PRJ-2026-001` |
+| ステータス | 初期値は `active` | `active` |
+| 予算 | 税込金額（円） | `50000000` |
+
+### API での作成
+
+```http
+POST /api/v1/projects/
+Authorization: Bearer {access_token}
+Content-Type: application/json
+
+{
+  "name": "渋谷ビル改修工事",
+  "project_code": "PRJ-2026-001",
+  "status": "active",
+  "budget": 50000000
+}
+```
+
+レスポンス:
+```json
+{
+  "id": 1,
+  "name": "渋谷ビル改修工事",
+  "project_code": "PRJ-2026-001",
+  "status": "active",
+  "budget": 50000000
+}
+```
+
+## 2. ステータスの遷移
+
+```
+planning → active → on_hold → completed
+                  ↘ cancelled
+```
+
+| ステータス | 意味 | 遷移可能先 |
+|---|---|---|
+| `planning` | 計画中 | `active`, `cancelled` |
+| `active` | 工事中 | `on_hold`, `completed`, `cancelled` |
+| `on_hold` | 一時停止 | `active`, `cancelled` |
+| `completed` | 完了 | (変更不可) |
+| `cancelled` | 中止 | (変更不可) |
+
+> **権限**: ステータス変更は `PROJECT_MANAGER` 以上のロールが必要です。
+
+## 3. 案件一覧を検索・フィルターする
+
+```http
+GET /api/v1/projects/?status=active&page=1&page_size=20
+Authorization: Bearer {access_token}
+```
+
+| パラメータ | 説明 | デフォルト |
+|---|---|---|
+| `status` | ステータスでフィルター | (全て) |
+| `search` | 案件名のキーワード検索 | (なし) |
+| `page` | ページ番号 | `1` |
+| `page_size` | 1ページの件数 | `20` (最大 `100`) |
+
+## 4. 日報を記録する
+
+案件詳細画面の「日報」タブから記録します。
+
+```http
+POST /api/v1/daily-reports/
+Authorization: Bearer {access_token}
+Content-Type: application/json
+
+{
+  "project_id": 1,
+  "report_date": "2026-04-25",
+  "weather": "晴",
+  "workers_count": 15,
+  "content": "基礎工事完了。明日から上棟予定。"
+}
+```
+
+## 5. 原価を記録する
+
+```http
+POST /api/v1/costs/
+Authorization: Bearer {access_token}
+Content-Type: application/json
+
+{
+  "project_id": 1,
+  "category": "materials",
+  "amount": 1500000,
+  "description": "鉄骨材料費",
+  "occurred_at": "2026-04-25"
+}
+```
+
+予実対比サマリーの確認:
+```http
+GET /api/v1/costs/summary/{project_id}
+```
+
+## 6. 安全確認チェックリストを使う
+
+```http
+POST /api/v1/safety/checks
+Authorization: Bearer {access_token}
+Content-Type: application/json
+
+{
+  "project_id": 1,
+  "check_date": "2026-04-25",
+  "items": [
+    {"category": "足場安全", "checked": true, "note": ""},
+    {"category": "KY活動", "checked": true, "note": "実施済み"}
+  ]
+}
+```
+
+## 関連ガイド
+
+- [はじめに](getting-started.md) — 環境構築
+- [管理者設定ガイド](admin-guide.md) — ユーザー・権限管理

--- a/docs/user-guide/getting-started.md
+++ b/docs/user-guide/getting-started.md
@@ -1,0 +1,81 @@
+# はじめに — ServiceHub Construction Platform
+
+5 分でセットアップして最初のログインまで到達するガイドです。
+
+## 前提条件
+
+| ツール | バージョン |
+|---|---|
+| Docker Engine | 24.0 以上 |
+| Docker Compose | 2.x 以上 |
+| (任意) curl / httpie | 動作確認用 |
+
+## ステップ 1: リポジトリ取得
+
+```bash
+git clone https://github.com/Kensan196948G/ServiceHub-Construction-Platform.git
+cd ServiceHub-Construction-Platform
+```
+
+## ステップ 2: 環境変数の設定
+
+```bash
+cp .env.example .env
+# .env を開き、以下の項目を確認・変更する
+# JWT_SECRET_KEY= (ランダム文字列に変更)
+# OPENAI_API_KEY= (AI検索を使用する場合)
+```
+
+> **セキュリティ注意**: `.env` をコミットしないでください。`.gitignore` に含まれています。
+
+## ステップ 3: サービス起動
+
+```bash
+docker compose up -d
+```
+
+初回はイメージビルドのため 2〜5 分かかります。
+
+## ステップ 4: 起動確認
+
+```bash
+curl http://localhost/health/live
+# {"status": "alive"} が返れば OK
+```
+
+ブラウザで `http://localhost` を開くとログイン画面が表示されます。
+
+## ステップ 5: 初回ログイン
+
+| 項目 | 値 |
+|---|---|
+| メールアドレス | `admin@servicehub.example` |
+| パスワード | `.env` 内の `INITIAL_ADMIN_PASSWORD` |
+
+> **本番環境**: 初回ログイン後に必ずパスワードを変更してください。
+
+## 次のステップ
+
+- [工事案件管理ガイド](construction-projects.md) — 案件の作成・管理
+- [管理者設定ガイド](admin-guide.md) — ユーザー・権限設定
+- [API 仕様](../09_API仕様（API%20Specifications）/) — プログラムから操作する場合
+- [デプロイメントガイド](../deployment/kubernetes.md) — Kubernetes 環境への展開
+
+## トラブルシューティング
+
+**サービスが起動しない場合**
+
+```bash
+docker compose logs backend --tail 50
+```
+
+**データベース接続エラー**
+
+```bash
+docker compose restart db
+docker compose run --rm backend alembic upgrade head
+```
+
+**ポート競合**
+
+`.env` で `BACKEND_PORT`, `FRONTEND_PORT` を変更後に再起動してください。


### PR DESCRIPTION
## Summary

- `docs/user-guide/` に 3 ガイド文書を新規作成（getting-started / construction-projects / admin-guide）
- FastAPI の OpenAPI `description` を Markdown 形式で拡充（認証フロー・ロール表・エラー形式・レート制限を明記）
- auth / projects / costs / safety の主要エンドポイント docstring を詳細化（権限・パラメータ・制限事項）
- README に「📚 ユーザードキュメント」セクション追加

## Test plan

- [x] `ruff check` — 全ファイル通過
- [x] `ruff format --check` — 全ファイル通過
- [x] `mypy --ignore-missing-imports` — 5 ファイル全通過
- [ ] CI 全チェック通過確認（PR CI 待ち）

## Impact

- ドキュメントのみ + docstring（ロジック変更なし）
- OpenAPI `/docs` に `description` が反映される
- 既存テストへの影響なし

## 残課題

- Issue #171 (Phase 10a CHANGELOG 整備) — 今後対応
- Issue #173 (Phase 10c セキュリティ監査 + v1.0.0 リリース) — 今後対応

Closes #172

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## ドキュメンテーション

* **Documentation**
  * READMEに新しいドキュメント案内ブロックを追加し、ロール別のユーザーガイドへのリンクを設置
  * 新規ユーザー向けの「はじめ方」ガイドを作成（環境構築手順、トラブルシューティング含む）
  * 建設プロジェクト管理ワークフローの完全ユーザーガイドを追加
  * 管理者向けガイドを追加（ユーザー管理、バックアップ、監視設定など）
  * APIエンドポイントのドキュメンテーション（認証、コスト、プロジェクト、安全チェック）を詳細化

<!-- end of auto-generated comment: release notes by coderabbit.ai -->