### PR TITLE
chore(ci): Node.js 24 明示採用 + ruff バージョン同期 (Closes #177)

### DIFF
--- a/.github/workflows/ci-deploy-staging.yml
+++ b/.github/workflows/ci-deploy-staging.yml
@@ -18,6 +18,7 @@ env:
   REGISTRY: ghcr.io
   IMAGE_OWNER: kensan196948g
   IMAGE_REPO: servicehub-construction-platform
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 jobs:
   build-and-push:

--- a/.github/workflows/ci-e2e-fullstack.yml
+++ b/.github/workflows/ci-e2e-fullstack.yml
@@ -14,6 +14,9 @@ concurrency:
   group: e2e-fullstack-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   e2e-fullstack:
     name: Fullstack E2E (Docker Compose)

--- a/.github/workflows/release-deadline-check.yml
+++ b/.github/workflows/release-deadline-check.yml
@@ -16,6 +16,9 @@ on:
 permissions:
   contents: read
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   check-deadline:
     runs-on: ubuntu-latest

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -57,7 +57,7 @@ factory-boy==3.3.1
 aiosqlite==0.20.0
 
 # ── Code Quality ─────────────────────────────────────
-ruff==0.6.9
+ruff==0.15.11
 mypy==1.11.2
 openai>=1.30.0
 schemathesis==3.38.9


### PR DESCRIPTION
## 変更内容

### 1. GitHub Actions Node.js 24 明示採用

`FORCE_JAVASCRIPT_ACTIONS_TO_NODE24="true"` を以下の3ワークフローに追加:
- `ci-deploy-staging.yml` — Docker Build & Push / Smoke Test
- `ci-e2e-fullstack.yml` — Playwright E2E (Docker Compose)
- `release-deadline-check.yml` — 毎日実行のデッドライン監視

`ci-backend.yml` / `security-scan.yml` 等は既に設定済み。

### 2. ruff バージョン同期

| ファイル | 変更前 | 変更後 |
|---|---|---|
| `backend/requirements.txt` | `ruff==0.6.9` | `ruff==0.15.11` |

CI (`ci-backend.yml`) と一致させてローカル/CI 差異を解消。

## 背景

- 2026-06-02: Node.js 20 アクションが Node.js 24 強制実行に移行
- 2026-09-16: Node.js 20 がランナーから完全削除
- 残38日 → P1 対処として本 PR を作成 (Issue #177)

## テスト結果

- CI全ジョブが現在 success であることを確認済み
- 変更は `env:` 追加 + バージョン番号更新のみで動作ロジック変更なし

## 影響範囲

- GitHub Actions ワークフロー (3ファイル): Node.js 24 警告解消
- `backend/requirements.txt`: ruff バージョン更新

## 残課題

なし

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * CI/CDワークフロー環境の設定を更新しました。
  * 開発ツールの依存関係を最新版に更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->