### PR TITLE
chore(ci): CodeQL Action v3 → v4 移行 + state.json 保守フェーズ同期 (Closes #179)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -30,15 +30,15 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
           queries: security-and-quality
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v3
+        uses: github/codeql-action/autobuild@v4
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4
         with:
           category: "/language:${{ matrix.language }}"

--- a/state.json
+++ b/state.json
@@ -9,11 +9,11 @@
     "release_policy": "半年後の本番リリース絶対厳守。残日数による自動縮退: <=30日 Improvement縮退 / <=14日 新機能開発禁止 / <=7日 リリース準備のみ",
     "phase_flexibility": "Monitor/Development/Verify/Improvement の配分は進捗に応じて CTO 判断で自由変更可 (リリース期限制約の下で)"
   },
-  "phase": "Phase 10 — 全完了 ✅ (10a CHANGELOG✅ / 10b ユーザードキュメント✅ / 10c v1.1.0リリース✅)",
-  "loop": "Day25-Phase10-Complete",
-  "loop_count": 163,
-  "status": "STABLE — GitHub Release v1.1.0 公開済み",
-  "last_updated": "2026-04-25T16:48:00+09:00",
+  "phase": "Maintenance — v1.1.0 保守フェーズ (CI強化・技術負債解消)",
+  "loop": "Day25-Maintenance-CIHardening",
+  "loop_count": 164,
+  "status": "STABLE — v1.1.0 Released / PR#178 Node.js24+ruff同期 / Issue#179 CodeQL v4移行中",
+  "last_updated": "2026-04-25T18:30:00+09:00",
   "execution": {
     "start_time": "2026-04-25T07:00:00+09:00",
     "max_duration_minutes": 300,
@@ -241,10 +241,12 @@
     }
   },
   "resume_point": {
-    "action": "Phase 9 全完了 → v0.9.0 タグ付与 → Phase 10 計画策定",
+    "action": "Maintenance: CodeQL v4移行 (Issue#179/PR#180) → 完了後はOpen Issue監視",
     "branch": "main",
-    "next_phase": "v0.9.0 git tag → push → Phase 10 (ユーザードキュメント・最終リリース準備) 計画",
-    "phase9_progress_note": "9a(監視スタック) ✅PR#168 / 9b(k6 SLO) ✅PR#169 / 9c(Kubernetes Helm) ✅PR#170 — 全完了"
+    "main_head_after_pr178": "79d8a20",
+    "next_phase": "保守フェーズ継続 — Open Issue 0目標維持 / 2026-10-03本番リリースまで残約161日",
+    "ci_hardening_done": "PR#178 — Node.js24明示採用 / ruff 0.15.11統一 (Issue#177 Closed)",
+    "pending_issues": ["Issue#179: CodeQL Action v3→v4 (P2 / 2026-12期限)"]
   },
   "phase6_plan": {
     "kickoff_at": "2026-04-24",


### PR DESCRIPTION
## 変更内容

### CodeQL Action v3 → v4 移行 (`.github/workflows/codeql.yml`)

CI で以下の deprecation 警告が検出されたため対応:
> CodeQL Action v3 will be deprecated in December 2026. Please update all occurrences of the CodeQL Action in your workflow files to v4.

変更箇所 (3件):
- `github/codeql-action/init@v3` → `@v4`
- `github/codeql-action/autobuild@v3` → `@v4`
- `github/codeql-action/analyze@v3` → `@v4`

### state.json 保守フェーズ同期

PR #178 merge (79d8a20) 後の状態を反映:
- `phase`: Maintenance フェーズへ更新
- `loop_count`: 163 → 164
- `resume_point`: CodeQL v4 移行・次アクション記録

## テスト結果

- CodeQL ジョブ: CI で確認予定 (python / javascript-typescript matrix)
- 既存 CI: PR #178 で全 10 チェック PASS 済み

## 影響範囲

- CI パイプラインの CodeQL セキュリティスキャン
- state.json の状態同期 (実行コードへの影響なし)

## 残課題

なし (Issue #179 本 PR で Closes)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * CI/インフラストラクチャの内部アップデートを実施しました。

---

**注:** このリリースは主に内部メンテナンスとCI改善に関するものであり、エンドユーザーに対する機能追加や変更はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->